### PR TITLE
Support jumping trains with locos in the back

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1426,9 +1426,9 @@ function(eventf)
 							})
 
 						elseif NewTrain.type == 'locomotive' then
-							local frontStock = NewTrain.train.front_stock
-							
-							if frontStock.name == 'RT-ghostLocomotive' then frontStock.destroy() end
+							for _, stock in pairs(NewTrain.train.carriages) do								
+								if stock.name == 'RT-ghostLocomotive' then stock.destroy() end
+							end
 						end
 
 						-- this order of setting speed -> manual mode -> schedule is very important, other orders mess up a lot more
@@ -1527,6 +1527,12 @@ function(eventf)
 					end
 					
 					for urmum, lol in pairs(boom.surface.find_entities_filtered({position = boom.position, radius = 4})) do
+						if lol.train ~= nil then
+							-- destroy ghost locos just to be safe
+							for _, stock in pairs(lol.train.carriages) do								
+								if stock.name == 'RT-ghostLocomotive' then stock.destroy() end
+							end
+						end
 						if (lol.valid and lol.is_entity_with_health == true and lol.health ~= nil) then
 							lol.damage(1000, "neutral", "explosion")
 						elseif (lol.valid and lol.name == "cliff") then

--- a/control.lua
+++ b/control.lua
@@ -1353,7 +1353,7 @@ function(eventf)
 						raise_built = true
 					})
 				global.FlyingTrains[PropUnitNumber].LandedTrain = NewTrain
-				--|||| Success	
+				--|||| Success
 				if (NewTrain ~= nil) then 
 					if (properties.passenger ~= nil) then
 						if (properties.passenger.is_player()) then
@@ -1387,6 +1387,50 @@ function(eventf)
 					end
 					
 					if (NewTrain.valid) then
+						if properties.leader == nil and NewTrain.type ~= "locomotive" then
+							local bb = NewTrain.prototype.collision_box
+							local length = bb.right_bottom.y - bb.left_top.y
+
+							length = length + 3 -- Add connection distance
+
+							local delta = {x = 0, y = 0}
+							local direction
+
+							-- Face the loco the direction the ramp is facing and
+							-- calculate its offset (down and to the right are positive)
+							if (properties.RampOrientation == 0) then
+								direction = defines.direction.south
+								delta.y = length
+							elseif (properties.RampOrientation == 0.25) then
+								direction = defines.direction.west
+								delta.x = -length
+							elseif (properties.RampOrientation == 0.50) then
+								direction = defines.direction.north
+								delta.y = -length
+							elseif (properties.RampOrientation == 0.75) then
+								direction = defines.direction.east
+								delta.x = length
+							end
+
+							-- game.print("Creating ghost loco offset by " .. serpent.block(delta) .. " direction " .. direction)
+
+							-- if it fails, that means there's a problem that the train is about to hit
+							-- so don't worry about it
+							local ghostLoco = NewTrain.surface.create_entity
+							({
+								name = 'RT-ghostLocomotive',
+								position = {x = NewTrain.position.x + delta.x, y = NewTrain.position.y + delta.y},
+								direction = direction,
+								force = NewTrain.force,
+								raise_built = false
+							})
+
+						elseif NewTrain.type == 'locomotive' then
+							local frontStock = NewTrain.train.front_stock
+							
+							if frontStock.name == 'RT-ghostLocomotive' then frontStock.destroy() end
+						end
+
 						-- this order of setting speed -> manual mode -> schedule is very important, other orders mess up a lot more
 						
 						if (properties.leader == nil) then
@@ -1402,8 +1446,7 @@ function(eventf)
 								NewTrain.train.speed = -math.abs(properties.speed)
 							end
 						end
-
-
+						
 						if (properties.leader == nil or (properties.follower == nil and properties.length == #NewTrain.train.carriages)) then
 							NewTrain.train.manual_mode = properties.ManualMode -- Trains are default created in manual mode
 						end
@@ -1453,7 +1496,7 @@ function(eventf)
 					properties.GuideCar.destroy()
 					
 				--|||| Failure
-				else 
+				else
 					if (properties.GuideCar.surface.find_tiles_filtered{position = properties.GuideCar.position, radius = 1, limit = 1, collision_mask = "player-layer"}[1] == nil) then
 						properties.GuideCar.surface.create_entity
 							({

--- a/data.lua
+++ b/data.lua
@@ -25,6 +25,7 @@ if (settings.startup["RTTrainRampSetting"].value == true) then
 	require("prototypes.TrainGoBrrrr.TrainRamp")
 	require("prototypes.TrainGoBrrrr.MagnetTrainRamp")
 	require("prototypes.TrainGoBrrrr.sprites.base")
+	require("prototypes.TrainGoBrrrr.GhostLoco")
 end
 
 if (settings.startup["RTZiplineSetting"].value == true) then

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "RenaiTransportation",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "title": "Renai Transportation",
     "author": "Kiplacon",
     "factorio_version": "1.0",

--- a/prototypes/TrainGoBrrrr/GhostLoco.lua
+++ b/prototypes/TrainGoBrrrr/GhostLoco.lua
@@ -1,0 +1,31 @@
+local baseLoco = data.raw['locomotive']['locomotive']
+
+data:extend{
+	{
+		type = "locomotive",
+		name = "RT-ghostLocomotive",
+		icon = baseLoco.icon,
+		icon_size = 64, icon_mipmaps = 4,
+		flags = {"placeable-neutral", "placeable-off-grid", "not-on-map", "hidden", "not-selectable-in-game"},
+		collision_box = baseLoco.collision_box,
+		max_health = 1,
+		weight = 0.000000001,
+		max_speed = 999,
+		max_power = "1J",
+		braking_power = "1J",
+		reversing_power_modifier = 0,
+		friction = 0.00000000001,
+		air_resistance = 0.000000000001, -- this is a percentage of current speed that will be subtracted
+		connection_distance = 3,
+		joint_distance = 4,
+		energy_source = {type = "void"},
+		vertical_selection_shift = -0.5,
+		energy_per_hit_point = 0,
+		pictures = {
+			direction_count = 1,
+			filename = "__core__/graphics/empty.png",
+			width = 1,
+			height = 1
+		}
+	}
+}


### PR DESCRIPTION
I was playing with this mod and noticed that "pusher" trains (ie, those with locos in the back instead of the front) don't work properly when jumped. Upon landing, the lead car immediately freezes in place, causing the following stock to land on top of it and destroy both of them.

This is apparently because factorio doesn't allow trains to be given a speed unless there's a locomotive in the train somewhere. Since the train is disassembled when jumping and reassembled when landing, the speed can't be set until a loco lands. When the train is headed by a loco, this is fine, but when it's headed by other stock, the speed setting fails and the newly spawned car remains stationary.

I fixed this by creating a new entity, a ghost locomotive, that's essentially a frictionless, powerless, invisible shell. When the mod lands a train, it checks if the first stock is a locomotive. If it isn't, it spawns the ghost loco ahead of the just-landed stock. This causes the first stock to join into a train with the ghost loco, and the subsequent speed setting succeeds. When a real locomotive lands, we remove any ghost locos from the train.

There's a slight edge case in this solution, namely that if the real loco is destroyed (or is never there, see below), the ghost loco will stay at the head of the train forever, or at least until it's taken off another jump.

I feel like train speed not being settable without a locomotive is a bug in factorio itself. It's possible to make a train that's moving with no loco (get the train moving and then press `v` while in the loco or destroy it), so it seems odd that a mod couldn't do this.

I've also made a test save for jumping push trains: [jump test.zip](https://github.com/Kiplacon/Renai-Transportation/files/5405396/jump.test.zip)
