### PR TITLE
Always set train to auto if it contains locos

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1212,7 +1212,7 @@ function(eventf)
 				-- end
 			-- end
 			-- global.AllPlayers[ThePlayer] = {}
-		
+
 		end		
 	end
 
@@ -1404,7 +1404,12 @@ function(eventf)
 						end
 
 
-						if (properties.leader == nil or (properties.follower == nil and properties.length == #NewTrain.train.carriages)) then
+						if (
+							(properties.leader == nil) or
+							(properties.follower == nil and properties.length == #NewTrain.train.carriages) or
+							(#NewTrain.train.locomotives.front_movers > 0 and NewTrain.train.speed > 0) or
+							(#NewTrain.train.locomotives.back_movers > 0 and NewTrain.train.speed < 0)
+						) then
 							NewTrain.train.manual_mode = properties.ManualMode -- Trains are default created in manual mode
 						end
 						

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "RenaiTransportation",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "title": "Renai Transportation",
     "author": "Kiplacon",
     "factorio_version": "1.0",


### PR DESCRIPTION
Simple fix for station skipping I touched on in #6, this always sets the train to auto if there's a loco facing the proper direction. Combined with #6, this should let all types of trains take appropriate forks, etc when the back part of the train is still mid-jump.