### PR TITLE
Fix filtered inventory bug

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1481,12 +1481,12 @@ function(eventf)
 								end
 							end
 						elseif (NewTrain.type == "cargo-wagon") then
-							for ItemName, quantity in pairs(properties.cargo) do
-								NewTrain.get_inventory(defines.inventory.cargo_wagon).insert({name = ItemName, count = quantity})
-							end
 							NewTrain.get_inventory(defines.inventory.cargo_wagon).set_bar(properties.bar)
 							for i, filter in pairs(properties.filter) do
 								NewTrain.get_inventory(defines.inventory.cargo_wagon).set_filter(i, filter)
+							end
+							for ItemName, quantity in pairs(properties.cargo) do
+								NewTrain.get_inventory(defines.inventory.cargo_wagon).insert({name = ItemName, count = quantity})
 							end
 						elseif (NewTrain.type == "fluid-wagon") then
 							for FluidName, quantity in pairs(properties.fluids) do


### PR DESCRIPTION
Noticed this when using a building train with many items in specific places. The mod was filling the inventory first, then setting the filters. This meant that the items in the train were sorted in default order when they landed, and then the old filters would be re-applied over top of them. This led to a situation where the filters were essentially useless, since stuff moved into slots that were filtered for a different item.