### PR TITLE
Raise destroy events for trains

### DIFF
--- a/script/event/entity_damaged.lua
+++ b/script/event/entity_damaged.lua
@@ -258,7 +258,7 @@ local function entity_damaged(event)
 			end
 		end
 
-		event.cause.destroy()
+		event.cause.destroy({ raise_destroy = true })
 	end
 end
 

--- a/script/trains/on_tick.lua
+++ b/script/trains/on_tick.lua
@@ -164,7 +164,7 @@ local function on_tick(event)
 							if (lol.valid and lol.is_entity_with_health == true and lol.health ~= nil) then
 								lol.damage(1000, "neutral", "explosion")
 							elseif (lol.valid and lol.name == "cliff") then
-								lol.destroy({do_cliff_correction = true})
+								lol.destroy({do_cliff_correction = true, raise_destroy = true})
 							end
 						end
 					end
@@ -324,7 +324,7 @@ local function on_tick(event)
 						if (lol.valid and lol.is_entity_with_health == true and lol.health ~= nil) then
 							lol.damage(1000, "neutral", "explosion")
 						elseif (lol.valid and lol.name == "cliff") then
-							lol.destroy({do_cliff_correction = true})
+							lol.destroy({do_cliff_correction = true,  raise_destroy = true})
 						end
 					end
 					


### PR DESCRIPTION
I found an issue with another mod (described here: https://github.com/robot256/MultipleUnitTrainControl/issues/13) which led me to notice that this one doesn't raise events when a train is destroyed. Hence this quick little PR :)

No sure if it's worth raising the destroy event elsewhere. My sense of the rules is you call destroy when:

- Destroying an entity you didn't create
- Destroying an entity that you created with raise_built

but I don't actually know :smile: 