### PR TITLE
Cleanup train animation code and add scaling to vertical jumps

### DIFF
--- a/prototypes/TrainGoBrrrr/MagnetTrainRamp.lua
+++ b/prototypes/TrainGoBrrrr/MagnetTrainRamp.lua
@@ -1,36 +1,3 @@
-local function scaleSprite(sprite, scale)
-	if sprite == nil then
-		return nil
-	end
-
-	local scaled = table.deepcopy(sprite)
-
-	if sprite.layers ~= nil then
-		scaled.layers = {}
-		for _, layer in pairs(sprite.layers) do
-			scaled.layers[_] = scaleSprite(layer, scale)
-		end
-	end
-
-	scaled.hr_version = scaleSprite(sprite.hr_version, scale)
-	scaled.north = scaleSprite(sprite.north, scale)
-	scaled.east = scaleSprite(sprite.east, scale)
-	scaled.south = scaleSprite(sprite.south, scale)
-	scaled.west = scaleSprite(sprite.west, scale)
-	scaled.sheet = scaleSprite(sprite.sheet, scale)
-
-	if sprite.sheets ~= nil then
-		scaled.sheets = {}
-		for _, sheet in pairs(sprite.sheets) do
-			scaled.sheets[_] = scaleSprite(sheet, scale)
-		end
-	end
-
-	scaled.scale = scale * (sprite.scale or 1)
-
-	return scaled
-end
-
 data:extend({ 
 
 --------------------------------------------Magnet train ramp
@@ -163,31 +130,33 @@ picture =
 	size = {105,169},
 	frame_count = 99,
 	line_length = 3
-}
+},
 
-})
-
-local accumulator = data.raw.accumulator.accumulator
-
-data:extend({
-	{
-		type = "electric-energy-interface",
-		name = "RTMagnetRampDrain",
-		icon = "__RenaiTransportation__/graphics/TrainRamp/icon2.png",
-		icon_size = 64,
-		flags = {"placeable-neutral", "placeable-off-grid", "not-on-map", "not-blueprintable", "not-deconstructable", "not-flammable", "no-copy-paste", "hidden", "not-rotatable"},
-		selection_box = {{-0.5, -0.5}, {0.5, 0.5}},
-		collision_box = {{-0.4, -0.4}, {0.4, 0.4}},
-		selection_priority = 101,
-		--collision_mask = {},
-		render_layer = "lower-object-above-shadow",
-		energy_source = {
+{
+	type = "electric-energy-interface",
+	name = "RTMagnetRampDrain",
+	icon = "__RenaiTransportation__/graphics/TrainRamp/icon2.png",
+	icon_size = 64,
+	flags = {"placeable-neutral", "placeable-off-grid", "not-on-map", "not-blueprintable", "not-deconstructable", "not-flammable", "no-copy-paste"},
+	selection_box = {{-0.5, -0.5}, {0.5, 0.5}},
+	collision_box = {{-0.4, -0.4}, {0.4, 0.4}},
+	selection_priority = 101,
+	--collision_mask = {},
+	render_layer = "lower-object-above-shadow",
+	energy_source = 
+		{
 			type = "electric",
 			usage_priority = "secondary-input",
 			input_flow_limit = "4MW"
 		},
-		picture = scaleSprite(accumulator.picture, 0.4),
-		light = accumulator.charge_light,
-		animation = scaleSprite(accumulator.charge_animation, 0.4)
-	}
+	picture = 
+		{
+			filename = "__base__/graphics/entity/accumulator/accumulator.png",
+			priority = "high",
+			width = 66,
+			height = 94,
+			scale = 0.4
+		}
+}
+
 })

--- a/prototypes/TrainGoBrrrr/MagnetTrainRamp.lua
+++ b/prototypes/TrainGoBrrrr/MagnetTrainRamp.lua
@@ -1,3 +1,36 @@
+local function scaleSprite(sprite, scale)
+	if sprite == nil then
+		return nil
+	end
+
+	local scaled = table.deepcopy(sprite)
+
+	if sprite.layers ~= nil then
+		scaled.layers = {}
+		for _, layer in pairs(sprite.layers) do
+			scaled.layers[_] = scaleSprite(layer, scale)
+		end
+	end
+
+	scaled.hr_version = scaleSprite(sprite.hr_version, scale)
+	scaled.north = scaleSprite(sprite.north, scale)
+	scaled.east = scaleSprite(sprite.east, scale)
+	scaled.south = scaleSprite(sprite.south, scale)
+	scaled.west = scaleSprite(sprite.west, scale)
+	scaled.sheet = scaleSprite(sprite.sheet, scale)
+
+	if sprite.sheets ~= nil then
+		scaled.sheets = {}
+		for _, sheet in pairs(sprite.sheets) do
+			scaled.sheets[_] = scaleSprite(sheet, scale)
+		end
+	end
+
+	scaled.scale = scale * (sprite.scale or 1)
+
+	return scaled
+end
+
 data:extend({ 
 
 --------------------------------------------Magnet train ramp
@@ -130,33 +163,31 @@ picture =
 	size = {105,169},
 	frame_count = 99,
 	line_length = 3
-},
+}
 
-{
-	type = "electric-energy-interface",
-	name = "RTMagnetRampDrain",
-	icon = "__RenaiTransportation__/graphics/TrainRamp/icon2.png",
-	icon_size = 64,
-	flags = {"placeable-neutral", "placeable-off-grid", "not-on-map", "not-blueprintable", "not-deconstructable", "not-flammable", "no-copy-paste"},
-	selection_box = {{-0.5, -0.5}, {0.5, 0.5}},
-	collision_box = {{-0.4, -0.4}, {0.4, 0.4}},
-	selection_priority = 101,
-	--collision_mask = {},
-	render_layer = "lower-object-above-shadow",
-	energy_source = 
-		{
+})
+
+local accumulator = data.raw.accumulator.accumulator
+
+data:extend({
+	{
+		type = "electric-energy-interface",
+		name = "RTMagnetRampDrain",
+		icon = "__RenaiTransportation__/graphics/TrainRamp/icon2.png",
+		icon_size = 64,
+		flags = {"placeable-neutral", "placeable-off-grid", "not-on-map", "not-blueprintable", "not-deconstructable", "not-flammable", "no-copy-paste", "hidden", "not-rotatable"},
+		selection_box = {{-0.5, -0.5}, {0.5, 0.5}},
+		collision_box = {{-0.4, -0.4}, {0.4, 0.4}},
+		selection_priority = 101,
+		--collision_mask = {},
+		render_layer = "lower-object-above-shadow",
+		energy_source = {
 			type = "electric",
 			usage_priority = "secondary-input",
 			input_flow_limit = "4MW"
 		},
-	picture = 
-		{
-			filename = "__base__/graphics/entity/accumulator/accumulator.png",
-			priority = "high",
-			width = 66,
-			height = 94,
-			scale = 0.4
-		}
-}
-
+		picture = scaleSprite(accumulator.picture, 0.4),
+		light = accumulator.charge_light,
+		animation = scaleSprite(accumulator.charge_animation, 0.4)
+	}
 })

--- a/script/event/entity_damaged.lua
+++ b/script/event/entity_damaged.lua
@@ -67,7 +67,7 @@ local function entity_damaged(event)
 			surface = SpookyGhost.surface,
 			orientation = event.cause.orientation,
 			x_scale = 0.25,
-			y_scale = 0.4,
+			y_scale = 0.5,
 			render_layer = 144
 			}
 

--- a/script/trains/animation.lua
+++ b/script/trains/animation.lua
@@ -28,6 +28,17 @@ function Animation.updateRendering(properties)
 	rendering.set_target(properties.MaskID, properties.GuideCar, {0, height})
 	rendering.set_target(properties.ShadowID, properties.GuideCar, {-height + 1, 0.5})
 
+	-- Going left or right, spin the car
+	local completedPercent = elapsed / properties.AirTime
+	local spinPercent = (2 * completedPercent) - 1 -- double the rotation arc and center it on 0, aka upright
+	local spinScale = (spinPercent ^ SpinSpeed) - spinPercent
+	local spinAmount = SpinMagnitude * spinScale
+
+	if (properties.RampOrientation == 0.75 or properties.RampOrientation == 0) then
+		-- Going right or down, reverse spin
+		spinAmount = -spinAmount
+	end
+
 	if (properties.RampOrientation == 0 or properties.RampOrientation == 0.50) then
 		-- Going down or up, zoom the car
 		local scaleDelta = math.abs(height) * 0.05
@@ -41,19 +52,10 @@ function Animation.updateRendering(properties)
 		local shadowScaleDelta = math.abs(height) * 0.025
 		rendering.set_x_scale(properties.ShadowID, 0.25 - shadowScaleDelta)
 		rendering.set_y_scale(properties.ShadowID, 0.5 - scaleDelta)
+
+		rendering.set_orientation(properties.ShadowID, spinAmount + 0.5)
 	end
 	if (properties.RampOrientation == 0.25 or properties.RampOrientation == 0.75) then
-		-- Going left or right, spin the car
-		local completedPercent = elapsed / properties.AirTime
-		local spinPercent = (2 * completedPercent) - 1 -- double the rotation arc and center it on 0, aka upright
-		local spinScale = (spinPercent ^ SpinSpeed) - spinPercent
-		local spinAmount = SpinMagnitude * spinScale
-
-		if properties.RampOrientation == 0.75 then
-			-- Going right, reverse spin
-			spinAmount = -spinAmount
-		end
-
 		rendering.set_orientation(properties.TrainImageID, spinAmount)
 		rendering.set_orientation(properties.MaskID, spinAmount)
 	end

--- a/script/trains/animation.lua
+++ b/script/trains/animation.lua
@@ -7,9 +7,7 @@ function Animation.updateRendering(properties)
 
 	if (properties.MagnetComp ~= nil) then
 		--if (properties.MagnetComp >= 0) then
-			-- Calculated gravity such that we reach a height of 5 tiles midway through the jump
-			-- a = -8 * (x / t^2)
-			gravity = (8 * 5) / (properties.AirTime) ^ 2
+			gravity = ((0.08 * properties.AirTime ^ 2) - (0.5 * properties.AirTime) + 11) / 125000
 
 			--SpinMagnitude = 0.05*properties.MagnetComp
 		if (properties.MagnetComp < 0) then
@@ -32,11 +30,14 @@ function Animation.updateRendering(properties)
 
 	if (properties.RampOrientation == 0 or properties.RampOrientation == 0.50) then
 		-- Going down or up, zoom the car
-		local scale = math.abs(height) * 0.05 + 0.5
+		local scaleDelta = math.abs(height) * 0.05
+		local scale = scaleDelta + 0.5
 		rendering.set_x_scale(properties.TrainImageID, scale)
 		rendering.set_y_scale(properties.TrainImageID, scale)
 		rendering.set_x_scale(properties.MaskID, scale)
 		rendering.set_y_scale(properties.MaskID, scale)
+		-- rendering.set_x_scale(properties.ShadowID, scale)
+		-- rendering.set_y_scale(properties.ShadowID, scale)
 	end
 	if (properties.RampOrientation == 0.25 or properties.RampOrientation == 0.75) then
 		-- Going left or right, spin the car

--- a/script/trains/animation.lua
+++ b/script/trains/animation.lua
@@ -5,7 +5,7 @@ function Animation.updateRendering(properties)
 
 	if (properties.MagnetComp ~= nil) then
 		--if (properties.MagnetComp >= 0) then
-			gravity = ((0.08 * properties.AirTime ^ 2) - (0.5 * properties.AirTime) + 11) / 125000
+			gravity = 2 / ((0.08 * properties.AirTime ^ 2) - (0.5 * properties.AirTime) + 11)
 
 			--SpinMagnitude = 0.05*properties.MagnetComp
 		if (properties.MagnetComp < 0) then

--- a/script/trains/animation.lua
+++ b/script/trains/animation.lua
@@ -59,11 +59,11 @@ function Animation.updateRotation(properties, elapsed)
 end
 
 function Animation.updateScale(properties, height)
-	local scaleDelta = math.abs(height) * 0.05
-	local scale = scaleDelta + 0.5
-
+	
 	if (properties.RampOrientation == 0 or properties.RampOrientation == 0.50) then
 		-- Going down or up, scale train to make it pop out
+		local scaleDelta = math.abs(height) * 0.05
+		local scale = scaleDelta + 0.5
 		rendering.set_x_scale(properties.TrainImageID, scale)
 		rendering.set_y_scale(properties.TrainImageID, scale)
 		rendering.set_x_scale(properties.MaskID, scale)

--- a/script/trains/animation.lua
+++ b/script/trains/animation.lua
@@ -61,10 +61,14 @@ end
 function Animation.updateScale(properties, height)
 	local scaleDelta = math.abs(height) * 0.05
 	local scale = scaleDelta + 0.5
-	rendering.set_x_scale(properties.TrainImageID, scale)
-	rendering.set_y_scale(properties.TrainImageID, scale)
-	rendering.set_x_scale(properties.MaskID, scale)
-	rendering.set_y_scale(properties.MaskID, scale)
+
+	if (properties.RampOrientation == 0 or properties.RampOrientation == 0.50) then
+		-- Going down or up, scale train to make it pop out
+		rendering.set_x_scale(properties.TrainImageID, scale)
+		rendering.set_y_scale(properties.TrainImageID, scale)
+		rendering.set_x_scale(properties.MaskID, scale)
+		rendering.set_y_scale(properties.MaskID, scale)
+	end
 
 	-- Scale shadow height differently to maintain perspective
 	local shadowScaleDelta = math.abs(height) * 0.025

--- a/script/trains/animation.lua
+++ b/script/trains/animation.lua
@@ -70,7 +70,7 @@ function Animation.updateScale(properties, height)
 	local shadowScaleDelta = math.abs(height) * 0.025
 
 	rendering.set_x_scale(properties.ShadowID, 0.25 - shadowScaleDelta)
-	rendering.set_y_scale(properties.ShadowID, 0.5 - scaleDelta)
+	rendering.set_y_scale(properties.ShadowID, 0.5 - shadowScaleDelta)
 end
 
 return Animation

--- a/script/trains/animation.lua
+++ b/script/trains/animation.lua
@@ -1,0 +1,58 @@
+local Animation = {}
+
+function Animation.updateRendering(properties)
+	local SpinMagnitude = 0.05
+	local SpinSpeed = 23
+	local gravity = 1/250 -- Approximately (9.8 m/s^2) from a 45 degree perspective, expressed in (m / tick^2). Affects arc "height", not air time or jump length
+
+	if (properties.MagnetComp ~= nil) then
+		--if (properties.MagnetComp >= 0) then
+			-- Calculated gravity such that we reach a height of 5 tiles midway through the jump
+			-- a = -8 * (x / t^2)
+			gravity = (8 * 5) / (properties.AirTime) ^ 2
+
+			--SpinMagnitude = 0.05*properties.MagnetComp
+		if (properties.MagnetComp < 0) then
+			--gravity = -30*properties.MagnetComp
+			--SpinSpeed = 19
+			--SpinMagnitude = 0.025
+		end
+	end
+
+	------------- animating -----------
+
+	local elapsed = game.tick - properties.LaunchTick;
+	local initialVerticalVelocity = -0.5 * (gravity * properties.AirTime) -- v_0 = -(1/2) * (a * t)
+	local height = (initialVerticalVelocity * elapsed) + (0.5 * gravity * (elapsed ^ 2)) -- x = (v_0 * t) + (1/2) * a * t^2
+
+	-- Adjust offset of rendered sprites
+	rendering.set_target(properties.TrainImageID, properties.GuideCar, {0, height})
+	rendering.set_target(properties.MaskID, properties.GuideCar, {0, height})
+	rendering.set_target(properties.ShadowID, properties.GuideCar, {-height, 0})
+
+	if (properties.RampOrientation == 0 or properties.RampOrientation == 0.50) then
+		-- Going down or up, zoom the car
+		local scale = math.abs(height) * 0.05 + 0.5
+		rendering.set_x_scale(properties.TrainImageID, scale)
+		rendering.set_y_scale(properties.TrainImageID, scale)
+		rendering.set_x_scale(properties.MaskID, scale)
+		rendering.set_y_scale(properties.MaskID, scale)
+	end
+	if (properties.RampOrientation == 0.25 or properties.RampOrientation == 0.75) then
+		-- Going left or right, spin the car
+		local completedPercent = elapsed / properties.AirTime
+		local spinPercent = (2 * completedPercent) - 1 -- double the rotation arc and center it on 0, aka upright
+		local spinScale = (spinPercent ^ SpinSpeed) - spinPercent
+		local spinAmount = SpinMagnitude * spinScale
+
+		if properties.RampOrientation == 0.75 then
+			-- Going right, reverse spin
+			spinAmount = -spinAmount
+		end
+
+		rendering.set_orientation(properties.TrainImageID, spinAmount)
+		rendering.set_orientation(properties.MaskID, spinAmount)
+	end
+end
+
+return Animation

--- a/script/trains/animation.lua
+++ b/script/trains/animation.lua
@@ -69,8 +69,8 @@ function Animation.updateScale(properties, height)
 	-- Scale shadow height differently to maintain perspective
 	local shadowScaleDelta = math.abs(height) * 0.025
 
-	rendering.set_x_scale(properties.ShadowID, 0.25 - shadowScaleDelta)
-	rendering.set_y_scale(properties.ShadowID, 0.5 - shadowScaleDelta)
+	rendering.set_x_scale(properties.ShadowID, 0.25 + shadowScaleDelta)
+	rendering.set_y_scale(properties.ShadowID, 0.5 + shadowScaleDelta)
 end
 
 return Animation

--- a/script/trains/animation.lua
+++ b/script/trains/animation.lua
@@ -26,7 +26,7 @@ function Animation.updateRendering(properties)
 	-- Adjust offset of rendered sprites
 	rendering.set_target(properties.TrainImageID, properties.GuideCar, {0, height})
 	rendering.set_target(properties.MaskID, properties.GuideCar, {0, height})
-	rendering.set_target(properties.ShadowID, properties.GuideCar, {-height, 0})
+	rendering.set_target(properties.ShadowID, properties.GuideCar, {-height + 1, 0.5})
 
 	if (properties.RampOrientation == 0 or properties.RampOrientation == 0.50) then
 		-- Going down or up, zoom the car
@@ -36,8 +36,11 @@ function Animation.updateRendering(properties)
 		rendering.set_y_scale(properties.TrainImageID, scale)
 		rendering.set_x_scale(properties.MaskID, scale)
 		rendering.set_y_scale(properties.MaskID, scale)
-		-- rendering.set_x_scale(properties.ShadowID, scale)
-		-- rendering.set_y_scale(properties.ShadowID, scale)
+		
+		-- make the shadow smaller with height
+		local shadowScaleDelta = math.abs(height) * 0.025
+		rendering.set_x_scale(properties.ShadowID, 0.25 - shadowScaleDelta)
+		rendering.set_y_scale(properties.ShadowID, 0.5 - scaleDelta)
 	end
 	if (properties.RampOrientation == 0.25 or properties.RampOrientation == 0.75) then
 		-- Going left or right, spin the car

--- a/script/trains/on_tick.lua
+++ b/script/trains/on_tick.lua
@@ -1,3 +1,5 @@
+local Animation = require("animation")
+
 local function on_tick(event)
 	--| Trains
 	----------------- train flight ----------------
@@ -365,43 +367,7 @@ local function on_tick(event)
 			end
 		--|| Animating Train
 		elseif (game.tick < properties.LandTick) then
-			local SpinMagnitude = 0.05
-			local SpinSpeed = 23
-			local gravity = 500 -- affects arc "height", not air time or jump length
-
-			if (properties.MagnetComp ~= nil) then
-				--if (properties.MagnetComp >= 0) then
-					gravity = 0.08*properties.AirTime^2-0.5*properties.AirTime+11
-					--SpinMagnitude = 0.05*properties.MagnetComp
-				if (properties.MagnetComp < 0) then
-					--gravity = -30*properties.MagnetComp
-					--SpinSpeed = 19
-					--SpinMagnitude = 0.025
-				end
-			end
-
-			------------- animating -----------
-			if (properties.RampOrientation == 0) then -- going down
-				rendering.set_target(properties.TrainImageID, properties.GuideCar, {0,((game.tick-properties.LaunchTick)^2-(game.tick-properties.LaunchTick)*properties.AirTime)/gravity})
-				rendering.set_target(properties.MaskID, properties.GuideCar, {0,((game.tick-properties.LaunchTick)^2-(game.tick-properties.LaunchTick)*properties.AirTime)/gravity})
-				rendering.set_target(properties.ShadowID, properties.GuideCar, {-((game.tick-properties.LaunchTick)^2-(game.tick-properties.LaunchTick)*properties.AirTime)/gravity,0})
-			elseif (properties.RampOrientation == 0.25) then -- going left
-				rendering.set_target(properties.TrainImageID, properties.GuideCar, {0,(game.tick-properties.LaunchTick)*((game.tick-properties.LaunchTick)-properties.AirTime)/gravity})
-				rendering.set_orientation(properties.TrainImageID, SpinMagnitude*( (2*(game.tick-properties.LaunchTick)/properties.AirTime-1)^SpinSpeed - (2*(game.tick-properties.LaunchTick)/properties.AirTime-1) ))
-				rendering.set_target(properties.MaskID, properties.GuideCar, {0,(game.tick-properties.LaunchTick)*((game.tick-properties.LaunchTick)-properties.AirTime)/gravity})
-				rendering.set_orientation(properties.MaskID, SpinMagnitude*( (2*(game.tick-properties.LaunchTick)/properties.AirTime-1)^SpinSpeed - (2*(game.tick-properties.LaunchTick)/properties.AirTime-1) ))
-				rendering.set_target(properties.ShadowID, properties.GuideCar, {-((game.tick-properties.LaunchTick)^2-(game.tick-properties.LaunchTick)*properties.AirTime)/gravity,0})
-			elseif (properties.RampOrientation == 0.50) then -- going up
-				rendering.set_target(properties.TrainImageID, properties.GuideCar, {0,((game.tick-properties.LaunchTick)^2-(game.tick-properties.LaunchTick)*properties.AirTime)/gravity})
-				rendering.set_target(properties.MaskID, properties.GuideCar, {0,((game.tick-properties.LaunchTick)^2-(game.tick-properties.LaunchTick)*properties.AirTime)/gravity})
-				rendering.set_target(properties.ShadowID, properties.GuideCar, {-((game.tick-properties.LaunchTick)^2-(game.tick-properties.LaunchTick)*properties.AirTime)/gravity,0})
-			elseif (properties.RampOrientation == 0.75) then -- going right
-				rendering.set_target(properties.TrainImageID, properties.GuideCar, {0,(game.tick-properties.LaunchTick)*((game.tick-properties.LaunchTick)-properties.AirTime)/gravity})
-				rendering.set_orientation(properties.TrainImageID, -SpinMagnitude*( (2*(game.tick-properties.LaunchTick)/properties.AirTime-1)^SpinSpeed - (2*(game.tick-properties.LaunchTick)/properties.AirTime-1) ))
-				rendering.set_target(properties.MaskID, properties.GuideCar, {0,(game.tick-properties.LaunchTick)*((game.tick-properties.LaunchTick)-properties.AirTime)/gravity})
-				rendering.set_orientation(properties.MaskID, -SpinMagnitude*( (2*(game.tick-properties.LaunchTick)/properties.AirTime-1)^SpinSpeed - (2*(game.tick-properties.LaunchTick)/properties.AirTime-1) ))
-				rendering.set_target(properties.ShadowID, properties.GuideCar, {-((game.tick-properties.LaunchTick)^2-(game.tick-properties.LaunchTick)*properties.AirTime)/gravity,0})
-			end
+			Animation.updateRendering(properties)
 
 		--|| Landing speed control
 		elseif (game.tick > properties.LandTick and properties.LandedTrain and properties.LandedTrain.valid) then


### PR DESCRIPTION
While looking into https://github.com/robot256/MultipleUnitTrainControl/issues/14, I found myself mired in the animation logic for trains. I was able to break the calculations out into discrete steps which can be reused and are also easier to follow. The net result is rendering logic now does approximately 1/3rd as many calculations as it used to.

Then, because I was already there, I added some code which subtly scales trains that are jumping north-south. This gives the impression the train is rising into the air, which I've found missing from those jumps. The east-west jumps have the rotating cars but there was nothing to distinguish a north-south jump from a train that was merely speeding up and slowing down.

Example effect, though horiibly compressed to fit in a gif:

![stretch-smol](https://user-images.githubusercontent.com/5599341/99474076-ed794100-2919-11eb-838f-f8163d7fd0e2.GIF)
