### PR TITLE
Use temporary stations when a train stop is limited

### DIFF
--- a/script/event/entity_damaged.lua
+++ b/script/event/entity_damaged.lua
@@ -109,6 +109,7 @@ local function entity_damaged(event)
 		global.FlyingTrains[SpookyGhost.unit_number].ShadowID = OwTheEdge
 		global.FlyingTrains[SpookyGhost.unit_number].ManualMode = event.cause.train.manual_mode
 		global.FlyingTrains[SpookyGhost.unit_number].length = #event.cause.train.carriages
+		global.FlyingTrains[SpookyGhost.unit_number].destinationStation = event.cause.train.path_end_stop
 
 		for number, properties in pairs(global.FlyingTrains) do -- carriages jumping before the ends land
 			if (properties.LandedTrain ~= nil and properties.LandedTrain.valid and event.cause.unit_number == properties.LandedTrain.unit_number) then

--- a/script/event/entity_damaged.lua
+++ b/script/event/entity_damaged.lua
@@ -110,6 +110,12 @@ local function entity_damaged(event)
 		global.FlyingTrains[SpookyGhost.unit_number].ManualMode = event.cause.train.manual_mode
 		global.FlyingTrains[SpookyGhost.unit_number].length = #event.cause.train.carriages
 		global.FlyingTrains[SpookyGhost.unit_number].destinationStation = event.cause.train.path_end_stop
+		global.FlyingTrains[SpookyGhost.unit_number].adjustDestinationLimit = event.cause.train.path_end_stop and event.cause.train.path_end_stop.trains_limit > 0
+
+		if global.FlyingTrains[SpookyGhost.unit_number].adjustDestinationLimit then
+			-- Artifically reserve the station by decrementing the available blocks
+			event.cause.train.path_end_stop.trains_limit = event.cause.train.path_end_stop.trains_limit - 1
+		end
 
 		for number, properties in pairs(global.FlyingTrains) do -- carriages jumping before the ends land
 			if (properties.LandedTrain ~= nil and properties.LandedTrain.valid and event.cause.unit_number == properties.LandedTrain.unit_number) then

--- a/script/trains/on_tick.lua
+++ b/script/trains/on_tick.lua
@@ -33,19 +33,21 @@ local function finalizeLandedTrain(PropUnitNumber, properties)
 		properties.destinationStation.trains_limit = properties.destinationStation.trains_limit + 1
 	end
 
-	-- Remove temporary pathing station, if present
-	local schedule = properties.LandedTrain.train.schedule
-	if schedule and schedule.current then
-		local dst = schedule.records[schedule.current]
+	if properties.LandedTrain and properties.LandedTrain.valid then
+		-- Remove temporary pathing station, if present
+		local schedule = properties.LandedTrain.train.schedule
+		if schedule and schedule.current then
+			local dst = schedule.records[schedule.current]
 
-		if dst and dst.wait_conditions then
-			local firstWaitCond = dst.wait_conditions[1]
+			if dst and dst.wait_conditions then
+				local firstWaitCond = dst.wait_conditions[1]
 
-			if firstWaitCond.condition and firstWaitCond.condition.first_signal and firstWaitCond.condition.first_signal.name == 'RTPropCarItem' then
-				local newSchedule = table.deepcopy(schedule)
-				table.remove(newSchedule.records, newSchedule.current)
-				properties.LandedTrain.train.schedule = newSchedule
-				properties.LandedTrain.train.go_to_station(newSchedule.current)
+				if firstWaitCond.condition and firstWaitCond.condition.first_signal and firstWaitCond.condition.first_signal.name == 'RTPropCarItem' then
+					local newSchedule = table.deepcopy(schedule)
+					table.remove(newSchedule.records, newSchedule.current)
+					properties.LandedTrain.train.schedule = newSchedule
+					properties.LandedTrain.train.go_to_station(newSchedule.current)
+				end
 			end
 		end
 	end

--- a/script/trains/on_tick.lua
+++ b/script/trains/on_tick.lua
@@ -28,6 +28,11 @@ local function reEnableSchedule(train, schedule, destinationStation)
 end
 
 local function finalizeLandedTrain(PropUnitNumber, properties)
+	-- undo station reservation
+	if properties.adjustDestinationLimit then
+		properties.destinationStation.trains_limit = properties.destinationStation.trains_limit + 1
+	end
+
 	-- Remove temporary pathing station, if present
 	local schedule = properties.LandedTrain.train.schedule
 	if schedule and schedule.current then


### PR DESCRIPTION
Resolves #20 by adding a temporary station to the train if the destination station is limited. Removes the temporary station after the train has landed.

Note that there is a possibility that the train will be unable to path to the station after we remove the temporary station. This happens because a second train could claim the reservation held by the first train while it is in the air. I might have a way around that, but for right now, the jumped train will stop dead immediately after landing until the destination becomes freed up.

Edit: Station reservation is now preserved on a best-effort basis while the train is in the air.