### PR TITLE
Easy optimization gains in FlyingItems' on_tick

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,20 +7,24 @@
         {
             "type": "factoriomod",
             "request": "launch",
-            "name": "Factorio Mod Debug"
+            "name": "Factorio Mod Debug",
+            "hookControl": ["RenaiTransportation"],
         },
         {
             "type": "factoriomod",
             "request": "launch",
             "name": "Factorio Mod Debug (Settings & Data)",
             "hookSettings": true,
-            "hookData": true
+            "hookData": true,
+            "hookControl": ["RenaiTransportation"],
         },
         {
             "type": "factoriomod",
             "request": "launch",
             "name": "Factorio Mod Debug (Profile)",
-            "hookMode": "profile"
+            "hookMode": "profile",
+            "hookControl": ["RenaiTransportation"],
+            "profileUpdateRate": 100,
         }
     ]
 }

--- a/script/event/FlyingItems.lua
+++ b/script/event/FlyingItems.lua
@@ -3,16 +3,19 @@ local function on_tick(event)
 
    for each, FlyingItem in pairs(global.FlyingItems) do
       local clear = true
-      if (game.tick < FlyingItem.LandTick and FlyingItem.player == nil) then
-         local duration = game.tick-FlyingItem.StartTick
+      if (event.tick < FlyingItem.LandTick and FlyingItem.player == nil) then
+         local duration = event.tick-FlyingItem.StartTick
          local progress = duration/FlyingItem.AirTime
-         local height = (duration/(FlyingItem.arc*FlyingItem.AirTime))-(duration^2/(FlyingItem.arc*FlyingItem.AirTime^2))
-         rendering.set_target(FlyingItem.sprite, {FlyingItem.start.x+(progress*FlyingItem.vector.x), FlyingItem.start.y+(progress*FlyingItem.vector.y)+height})
-         rendering.set_target(FlyingItem.shadow, {FlyingItem.start.x+(progress*FlyingItem.vector.x)-height, FlyingItem.start.y+(progress*FlyingItem.vector.y)})
-         rendering.set_orientation(FlyingItem.sprite, rendering.get_orientation(FlyingItem.sprite)+FlyingItem.spin)
-         rendering.set_orientation(FlyingItem.shadow, rendering.get_orientation(FlyingItem.shadow)+FlyingItem.spin)
+         local height = progress * (1-progress) / FlyingItem.arc
+         local x_coord = FlyingItem.start.x+(progress*FlyingItem.vector.x)
+         local y_coord = FlyingItem.start.y+(progress*FlyingItem.vector.y)
+         local orientation = rendering.get_orientation(FlyingItem.sprite)+FlyingItem.spin
+         rendering.set_target(FlyingItem.sprite, {x_coord, y_coord + height})
+         rendering.set_target(FlyingItem.shadow, {x_coord - height, y_coord})
+         rendering.set_orientation(FlyingItem.sprite, orientation)
+         rendering.set_orientation(FlyingItem.shadow, orientation)
 
-      elseif (game.tick == FlyingItem.LandTick and FlyingItem.space == nil) then
+      elseif (event.tick == FlyingItem.LandTick and FlyingItem.space == nil) then
          local ThingLandedOn = rendering.get_surface(FlyingItem.sprite).find_entities_filtered
             {
                position = {math.floor(FlyingItem.target.x)+0.5, math.floor(FlyingItem.target.y)+0.5},


### PR DESCRIPTION
As described in this post: https://www.reddit.com/r/factorio/comments/12yj35v/codingwise_how_can_i_reduce_lag_from_my_mod/jhp7s0u/?context=3

Most optimization suggestions credit to /u/Soul-Burn.

I also added some parameters to your launch settings to make it easier to profile and debug. (`hookControl` makes it so that the debugger/profiler only cares about Renai Transportation code instead of every single mod, `profileUpdateRate` from 500 to 100 makes the profiler update more often.)

Further gains are possible but are not as easy :)