### PR TITLE
Fix/update Ultracube compat

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -135,9 +135,11 @@ function(event)
 		for i = 1, #container.get_output_inventory() do
 			local stack = container.get_output_inventory()[i]
 			if (stack.valid_for_read == true) then
-				stack.count = math.ceil(stack.count*0.5) -- half the items lost in the destruction
+				if not (storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[stack.name]) then
+					stack.count = math.ceil(stack.count*0.5) -- half the items lost in the destruction
+				end
 				local GroupSize = math.ceil((stack.count/17))
-				for _ = 1, math.floor(stack.count/GroupSize) do
+				while stack.count > 0 do
 					-- unit vector
 					local angle = math.random(0, 100)*0.01
 					local xUnit = math.cos(2*math.pi*angle)
@@ -158,11 +160,12 @@ function(event)
 							height = progress * (1-progress) / arc
 						}
 					end
+					local ThrowFromStackAmount = math.min(GroupSize, stack.count)
 					InvokeThrownItem({
 						type = "CustomPath",
 						render_layer = "elevated-higher-object",
 						stack = stack,
-						ThrowFromStackAmount = GroupSize,
+						ThrowFromStackAmount = ThrowFromStackAmount,
 						start = container.position,
 						target = {x=TargetX, y=TargetY},
 						path = path,

--- a/script/ThrowItemFunctions.lua
+++ b/script/ThrowItemFunctions.lua
@@ -843,7 +843,7 @@ function ResolveThrownItem(FlyingItem)
                     else
                         storage.ThrowerPaths[OnDestroyNumber][FlyingItem.tracing][FlyingItem.item] = true
                     end
-                    
+
                 elseif (ThingLandedOn.unit_number == nil) then -- cliffs/trees/other things without unit_numbers
                     storage.CatapultList[FlyingItem.tracing].targets[FlyingItem.item] = "nothing"
 
@@ -986,7 +986,7 @@ function ResolveThrownItem(FlyingItem)
         storage.CatapultList[FlyingItem.tracing].ImAlreadyTracer = "traced"
         storage.CatapultList[FlyingItem.tracing].targets[FlyingItem.item] = "nothing"
     end
-    
+
     -- cleanup
     -- overflow tracking
     if (FlyingItem.tracing == nil and ClearOverflowTracking == true and FlyingItem.DestinationDestroyNumber ~= nil and storage.OnTheWay[FlyingItem.DestinationDestroyNumber]) then

--- a/script/ThrowItemFunctions.lua
+++ b/script/ThrowItemFunctions.lua
@@ -438,7 +438,7 @@ function ResolveThrownItem(FlyingItem)
     if (FlyingItem.type == "ItemShell") then
         -- By the time this called the ownership token should have been released already
         -- If for some reason that's not the case, trigger Ultracube's forced recovery
-        if FlyingItem.cube_token_id then
+        if storage.Ultracube and FlyingItem.cube_token_id then
             CubeFlyingItems.panic(FlyingItem)
         end
 

--- a/script/ThrowItemFunctions.lua
+++ b/script/ThrowItemFunctions.lua
@@ -67,6 +67,7 @@ function InvokeThrownItem(stuff)
                         target_position={TargetX, TargetY}
                     }
                 end
+                FlyingItem.speed = speed
                 local StreamDestroyNumber = script.register_on_object_destroyed(stream)
                 FlyingItem.StreamDestroyNumber = StreamDestroyNumber
                 storage.FlyingItems[StreamDestroyNumber] = FlyingItem
@@ -117,16 +118,12 @@ function InvokeThrownItem(stuff)
                 storage.FlyingItems[FlightNumber] = FlyingItem
                 storage.CustomPathFlyingItemSprites[FlightNumber] = true
             elseif (ProjectileType == "ItemShell") then
-                local projectile = FlyingItem.surface.create_entity
-                {
-                    name="RTItemShell"..FlyingItem.item,
-                    source = stuff.cannon, -- so it doesnt clip the cannon
-                    position = stuff.cannon.position, -- start position
-                    target = FlyingItem.target,
-                    speed=storage.ItemCannonSpeed,
-                    max_range = 100
-                }
-                local ProjectileDestroyNumber = script.register_on_object_destroyed(projectile)
+                -- Only for Ultracube (otherwise item shells are handled entirely in effect_triggered)
+                -- Projectile creation already handled by on_tick_ItemCannons
+                FlyingItem.AirTime = math.ceil((storage.ItemCannonRange or 200) / storage.ItemCannonSpeed) -- err towards maximum possible AirTime
+                FlyingItem.StartTick = game.tick
+                FlyingItem.projectile = stuff.projectile
+                local ProjectileDestroyNumber = script.register_on_object_destroyed(stuff.projectile)
                 FlyingItem.StreamDestroyNumber = ProjectileDestroyNumber
                 storage.FlyingItems[ProjectileDestroyNumber] = FlyingItem
 
@@ -165,9 +162,15 @@ function InvokeThrownItem(stuff)
             end
 
             -- Ultracube irreplaceables detection & handling
-            if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then -- Ultracube mod is active, and the held item is an irreplaceable
-                -- Sets cube_token_id and cube_should_hint for the new FlyingItems entry
-                CubeFlyingItems.create_token_for(FlyingItem)
+            if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] and FlyingItem.amount > 0 then -- Ultracube mod is active, and the held item is an irreplaceable
+                FlyingItem.speed = speed
+                if stuff.bouncing and stuff.bouncing.cube_token_id then
+                    -- Update and transfer an existing cube_token_id to the new FlyingItem
+                    CubeFlyingItems.bounce_update(stuff.bouncing, FlyingItem)
+                else
+                    -- Sets cube_token_id and cube_should_hint for the new FlyingItems entry
+                    CubeFlyingItems.create_token_for(FlyingItem)
+                end
             end
             return FlyingItem
 
@@ -428,8 +431,19 @@ function ResolveThrownItem(FlyingItem)
             area = {{FlyingItem.target.x-0.5, FlyingItem.target.y-0.5}, {FlyingItem.target.x+0.5, FlyingItem.target.y+0.5}},
             type = "cargo-wagon"
         }[1]
+
+    -- dummy ItemShells for Ultracube
+    if (FlyingItem.type == "ItemShell") then
+        -- By the time this called the ownership token should have been released already
+        -- If for some reason that's not the case, trigger Ultracube's forced recovery
+        if FlyingItem.cube_token_id then
+            CubeFlyingItems.panic(FlyingItem)
+        end
+
+        -- do nothing else except cleanup
+
     -- landed on something
-    if (ThingLandedOn) then
+    elseif (ThingLandedOn) then
         --game.print(ThingLandedOn.name)
         if (string.find(ThingLandedOn.name, "BouncePlate") and FlyingItem.type ~= "ItemShell") then -- if that thing was a bounce plate
             if (FlyingItem.sprite) then -- from impact unloader

--- a/script/ThrowItemFunctions.lua
+++ b/script/ThrowItemFunctions.lua
@@ -67,7 +67,6 @@ function InvokeThrownItem(stuff)
                         target_position={TargetX, TargetY}
                     }
                 end
-                FlyingItem.speed = speed
                 local StreamDestroyNumber = script.register_on_object_destroyed(stream)
                 FlyingItem.StreamDestroyNumber = StreamDestroyNumber
                 storage.FlyingItems[StreamDestroyNumber] = FlyingItem
@@ -164,6 +163,9 @@ function InvokeThrownItem(stuff)
             -- Ultracube irreplaceables detection & handling
             if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] and FlyingItem.amount > 0 then -- Ultracube mod is active, and the held item is an irreplaceable
                 FlyingItem.speed = speed
+                if (stuff.thrower and stuff.thrower.name ~= "RTThrower-EjectorHatchRT") then
+                    FlyingItem.StreamStart = stuff.thrower.held_stack_position
+                end
                 if stuff.bouncing and stuff.bouncing.cube_token_id then
                     -- Update and transfer an existing cube_token_id to the new FlyingItem
                     CubeFlyingItems.bounce_update(stuff.bouncing, FlyingItem)

--- a/script/event/FlyingItems.lua
+++ b/script/event/FlyingItems.lua
@@ -21,8 +21,8 @@ local function on_tick(event)
             FlyingItem.shadow.color = {0, 0, 0, 2.5/(5-height)}
          end
 
-         if storage.Ultracube and FlyingItem.cube_token_id then
-            CubeFlyingItems.item_with_sprite_update(FlyingItem, duration)
+         if storage.Ultracube and FlyingItem.cube_should_hint then
+            CubeFlyingItems.item_with_path_update(FlyingItem, duration)
          end
 
       elseif (FlyingItem and event.tick == FlyingItem.LandTick and FlyingItem.space == false) then
@@ -44,9 +44,15 @@ local function on_tick(event)
 
    if (storage.Ultracube) then
       for each, FlyingItem in pairs(storage.FlyingItems) do
-         if (FlyingItem.sprite == nil and FlyingItem.cube_should_hint and event.tick < FlyingItem.LandTick) then
+         if FlyingItem.cube_should_hint and event.tick < (FlyingItem.StartTick + FlyingItem.AirTime) then
             -- Ultracube non-sprite item position updating. Only done for items that require hinting as those are the ones the cube camera follows
-            CubeFlyingItems.item_with_stream_update(FlyingItem)
+            if FlyingItem.path then
+               CubeFlyingItems.item_with_path_update(FlyingItem, event.tick - FlyingItem.StartTick)
+            elseif FlyingItem.type == "ReskinnedStream" then
+               CubeFlyingItems.item_with_stream_update(FlyingItem)
+            elseif FlyingItem.type == "ItemShell" then
+               CubeFlyingItems.item_with_shell_update(FlyingItem)
+            end
          end
       end
    end

--- a/script/event/effect_triggered.lua
+++ b/script/event/effect_triggered.lua
@@ -113,52 +113,202 @@ local function effect_triggered(event)
 			-- If Ultracube recovered the item don't do anything
 			local projectile = surface.find_entity(event.effect_id, event.target_position)
 			if not CubeFlyingItems.release_for_projectile(projectile) then
-				skip_ultracube = true
+				return
 			end
 		end
 
-		if not skip_ultracube then
-			if (event.target_entity) then
-				local HitEntity = event.target_entity
-				if (HitEntity.name == "RTRicochetPanel") then
-					if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
-						-- the following code was brought to you by ChatGPT cause im way too dumb to come up with this but basically it reflects the item shell off the panel in an angle in = angle out way based on whether the panel is vertical or horizontal. It's actually good enough to handle the panel being at any angle but that sounds like a pain to actually use in game
-							local start = event.source_position
-							local HitPosition = event.target_position
-							local object = HitEntity
-							-- positions
-							local p_x, p_y = start.x, start.y
-							local o_x, o_y = HitPosition.x, HitPosition.y
-							local PanelOrientation = object.orientation  -- [0, 1)
-							-- 1) Compute the projectile's incoming direction (v_x, v_y).
-							--    Let's assume we want center-to-center for simplicity:
-							local v_x = o_x - p_x
-							local v_y = o_y - p_y
-							local v_len = math.sqrt(v_x*v_x + v_y*v_y)
-							if v_len > 0 then
-								v_x = v_x / v_len
-								v_y = v_y / v_len
-							end
-							-- 2) Compute the normal from Factorio orientation
-							local theta = 2 * math.pi * PanelOrientation
-							local n_x = math.cos(theta - math.pi/2)
-							local n_y = math.sin(theta - math.pi/2)
-							-- 3) Reflect v about n
-							local dot = (v_x * n_x) + (v_y * n_y)
-							local r_x = v_x - 2 * dot * n_x
-							local r_y = v_y - 2 * dot * n_y
-							-- r_x, r_y now points in the bounced (reflected) direction.
-						local target = OffsetPosition(HitPosition, {100*r_x, 100*r_y})
+		if (event.target_entity) then
+			local HitEntity = event.target_entity
+			if (HitEntity.name == "RTRicochetPanel") then
+				if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
+					-- the following code was brought to you by ChatGPT cause im way too dumb to come up with this but basically it reflects the item shell off the panel in an angle in = angle out way based on whether the panel is vertical or horizontal. It's actually good enough to handle the panel being at any angle but that sounds like a pain to actually use in game
+						local start = event.source_position
+						local HitPosition = event.target_position
+						local object = HitEntity
+						-- positions
+						local p_x, p_y = start.x, start.y
+						local o_x, o_y = HitPosition.x, HitPosition.y
+						local PanelOrientation = object.orientation  -- [0, 1)
+						-- 1) Compute the projectile's incoming direction (v_x, v_y).
+						--    Let's assume we want center-to-center for simplicity:
+						local v_x = o_x - p_x
+						local v_y = o_y - p_y
+						local v_len = math.sqrt(v_x*v_x + v_y*v_y)
+						if v_len > 0 then
+							v_x = v_x / v_len
+							v_y = v_y / v_len
+						end
+						-- 2) Compute the normal from Factorio orientation
+						local theta = 2 * math.pi * PanelOrientation
+						local n_x = math.cos(theta - math.pi/2)
+						local n_y = math.sin(theta - math.pi/2)
+						-- 3) Reflect v about n
+						local dot = (v_x * n_x) + (v_y * n_y)
+						local r_x = v_x - 2 * dot * n_x
+						local r_y = v_y - 2 * dot * n_y
+						-- r_x, r_y now points in the bounced (reflected) direction.
+					local target = OffsetPosition(HitPosition, {100*r_x, 100*r_y})
+					local projectile = surface.create_entity
+					{
+						name=event.effect_id,
+						source = HitEntity,
+						position = HitPosition,
+						target = target,
+						speed=speed,
+						max_range = storage.ItemCannonRange or 200
+					}
+
+					-- Ultracube irreplaceables detection & handling
+					if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
+						-- Create a dummy FlyingItem so we can track it for Ultracube
+						InvokeThrownItem({
+							type = "ItemShell",
+							ItemName = ItemName,
+							count = prototypes.item[ItemName].stack_size,
+							quality = QualityName,
+							start = HitPosition,
+							target = target,
+							surface = surface,
+							projectile = projectile,
+						})
+					end
+
+					if (not LaserPointer) then
+						HitEntity.energy = 0
+						surface.play_sound
+						{
+							path = "RTRicochetPanelSpark",
+							position = HitEntity.position,
+							volume_modifier = 0.5
+						}
+						rendering.draw_animation
+						{
+							animation = "RTRicochetPanelZap",
+							target = {entity=HitEntity, offset={0,-0.6}},
+							surface = HitEntity.surface,
+							time_to_live = 20,
+							x_scale = 0.4,
+							y_scale = 0.8,
+						}
+					end
+				else
+					eject = true
+					--debris = false
+					if (not LaserPointer) then
+						HitEntity.die()
+					end
+				end
+			elseif (HitEntity.name == "RTCatchingChute" and not LaserPointer) then
+				surface.play_sound
+				{
+					path = "RTClunk",
+					position = HitEntity.position
+				}
+				inserted = HitEntity.insert({name=ItemName, count=prototypes.item[ItemName].stack_size, quality=QualityName})
+				if (inserted < prototypes.item[ItemName].stack_size) then
+					eject = true
+					debris = false
+				end
+				-- Ultracube irreplaceables detection & handling
+				if storage.Ultracube and inserted > 0 and storage.Ultracube.prototypes.cube[ItemName] then
+					-- hint if needed
+					remote.call("Ultracube", "hint_entity", HitEntity)
+				end
+			elseif (HitEntity.name == "RTMergingChute") then
+				if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
+					local start = event.source_position
+					local HitPosition = event.target_position
+					local deltaX = HitPosition.x - start.x
+					local deltaY = HitPosition.y - start.y
+					local angle = math.atan2(deltaY, deltaX) - 3*math.pi/4 -- to align with the 45 degree tilt of the chute
+					local ProjectileOrientation = (angle / (2 * math.pi)) % 1
+					if (ProjectileOrientation ~= HitEntity.orientation and (ProjectileOrientation+0.5)%1 ~= HitEntity.orientation) then
+						local OutVector = storage.ChuteOrientationComponents[HitEntity.orientation]
+						local target = OffsetPosition(HitEntity.position, {100*OutVector.x, 100*OutVector.y})
 						local projectile = surface.create_entity
 						{
 							name=event.effect_id,
 							source = HitEntity,
-							position = HitPosition,
+							position = HitEntity.position,
 							target = target,
 							speed=speed,
 							max_range = storage.ItemCannonRange or 200
 						}
 
+						-- Ultracube irreplaceables detection & handling
+						if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
+							-- Create a dummy FlyingItem so we can track it for Ultracube
+							InvokeThrownItem({
+								type = "ItemShell",
+								ItemName = ItemName,
+								count = prototypes.item[ItemName].stack_size,
+								quality = QualityName,
+								start = HitEntity.position,
+								target = target,
+								surface = surface,
+								projectile = projectile,
+							})
+						end
+
+						if (not LaserPointer) then
+							HitEntity.energy = 0
+							surface.play_sound
+							{
+								path = "RTRicochetPanelSpark",
+								position = HitEntity.position,
+								volume_modifier = 0.5
+							}
+							rendering.draw_animation
+							{
+								animation = "RTRicochetPanelZap",
+								target = {entity=HitEntity, offset={0,-0.6}},
+								surface = HitEntity.surface,
+								time_to_live = 20,
+								x_scale = 0.4,
+								y_scale = 0.4,
+							}
+						end
+					else
+						eject = true
+						debris = false
+					end
+				else
+					eject = true
+					if (not LaserPointer) then
+						HitEntity.die()
+					end
+				end
+			elseif (HitEntity.name == "RTDivergingChute") then
+				if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
+					local start = event.source_position
+					local HitPosition = event.target_position
+					local deltaX = HitPosition.x - start.x
+					local deltaY = HitPosition.y - start.y
+					local angle = math.atan2(deltaY, deltaX) - 3*math.pi/4 -- to align with the 45 degree tilt of the chute
+					local ProjectileOrientation = (angle / (2 * math.pi)) % 1
+					--game.print(ProjectileOrientation.." | "..HitEntity.orientation)
+					--if (math.floor((ProjectileOrientation*100) + 0.5) == math.floor((HitEntity.orientation*100) + 0.5)) then
+					if (ProjectileOrientation == HitEntity.orientation) then
+						local OutX = storage.ChuteOrientationComponents[HitEntity.orientation].x
+						local OutY = storage.ChuteOrientationComponents[HitEntity.orientation].y
+						-- flips either X or Y direction to bounce out one way or the other. destructible isn't relavent 99% of the time so i use it to track the direction it deflected last
+						if (HitEntity.destructible) then
+							OutX = -OutX
+							HitEntity.destructible = false
+						else
+							OutY = -OutY
+							HitEntity.destructible = true
+						end
+						local target = OffsetPosition(HitEntity.position, {100*OutX, 100*OutY})
+						local projectile = surface.create_entity
+						{
+							name=event.effect_id,
+							source = HitEntity,
+							position = HitEntity.position,
+							target = target,
+							speed=speed,
+							max_range = storage.ItemCannonRange or 200
+						}
 						-- Ultracube irreplaceables detection & handling
 						if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
 							-- Create a dummy FlyingItem so we can track it for Ultracube
@@ -189,242 +339,90 @@ local function effect_triggered(event)
 								surface = HitEntity.surface,
 								time_to_live = 20,
 								x_scale = 0.4,
-								y_scale = 0.8,
+								y_scale = 0.4,
 							}
 						end
 					else
-						eject = true
-						--debris = false
-						if (not LaserPointer) then
-							HitEntity.die()
-						end
-					end
-				elseif (HitEntity.name == "RTCatchingChute" and not LaserPointer) then
-					surface.play_sound
-					{
-						path = "RTClunk",
-						position = HitEntity.position
-					}
-					inserted = HitEntity.insert({name=ItemName, count=prototypes.item[ItemName].stack_size, quality=QualityName})
-					if (inserted < prototypes.item[ItemName].stack_size) then
 						eject = true
 						debris = false
 					end
-					-- Ultracube irreplaceables detection & handling
-					if storage.Ultracube and inserted > 0 and storage.Ultracube.prototypes.cube[ItemName] then
-						-- hint if needed
-						remote.call("Ultracube", "hint_entity", HitEntity)
-					end
-				elseif (HitEntity.name == "RTMergingChute") then
-					if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
-						local start = event.source_position
-						local HitPosition = event.target_position
-						local deltaX = HitPosition.x - start.x
-						local deltaY = HitPosition.y - start.y
-						local angle = math.atan2(deltaY, deltaX) - 3*math.pi/4 -- to align with the 45 degree tilt of the chute
-						local ProjectileOrientation = (angle / (2 * math.pi)) % 1
-						if (ProjectileOrientation ~= HitEntity.orientation and (ProjectileOrientation+0.5)%1 ~= HitEntity.orientation) then
-							local OutVector = storage.ChuteOrientationComponents[HitEntity.orientation]
-							local target = OffsetPosition(HitEntity.position, {100*OutVector.x, 100*OutVector.y})
-							local projectile = surface.create_entity
-							{
-								name=event.effect_id,
-								source = HitEntity,
-								position = HitEntity.position,
-								target = target,
-								speed=speed,
-								max_range = storage.ItemCannonRange or 200
-							}
-
-							-- Ultracube irreplaceables detection & handling
-							if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
-								-- Create a dummy FlyingItem so we can track it for Ultracube
-								InvokeThrownItem({
-									type = "ItemShell",
-									ItemName = ItemName,
-									count = prototypes.item[ItemName].stack_size,
-									quality = QualityName,
-									start = HitEntity.position,
-									target = target,
-									surface = surface,
-									projectile = projectile,
-								})
-							end
-
-							if (not LaserPointer) then
-								HitEntity.energy = 0
-								surface.play_sound
-								{
-									path = "RTRicochetPanelSpark",
-									position = HitEntity.position,
-									volume_modifier = 0.5
-								}
-								rendering.draw_animation
-								{
-									animation = "RTRicochetPanelZap",
-									target = {entity=HitEntity, offset={0,-0.6}},
-									surface = HitEntity.surface,
-									time_to_live = 20,
-									x_scale = 0.4,
-									y_scale = 0.4,
-								}
-							end
-						else
-							eject = true
-							debris = false
-						end
-					else
-						eject = true
-						if (not LaserPointer) then
-							HitEntity.die()
-						end
-					end
-				elseif (HitEntity.name == "RTDivergingChute") then
-					if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
-						local start = event.source_position
-						local HitPosition = event.target_position
-						local deltaX = HitPosition.x - start.x
-						local deltaY = HitPosition.y - start.y
-						local angle = math.atan2(deltaY, deltaX) - 3*math.pi/4 -- to align with the 45 degree tilt of the chute
-						local ProjectileOrientation = (angle / (2 * math.pi)) % 1
-						--game.print(ProjectileOrientation.." | "..HitEntity.orientation)
-						--if (math.floor((ProjectileOrientation*100) + 0.5) == math.floor((HitEntity.orientation*100) + 0.5)) then
-						if (ProjectileOrientation == HitEntity.orientation) then
-							local OutX = storage.ChuteOrientationComponents[HitEntity.orientation].x
-							local OutY = storage.ChuteOrientationComponents[HitEntity.orientation].y
-							-- flips either X or Y direction to bounce out one way or the other. destructible isn't relavent 99% of the time so i use it to track the direction it deflected last
-							if (HitEntity.destructible) then
-								OutX = -OutX
-								HitEntity.destructible = false
-							else
-								OutY = -OutY
-								HitEntity.destructible = true
-							end
-							local target = OffsetPosition(HitEntity.position, {100*OutX, 100*OutY})
-							local projectile = surface.create_entity
-							{
-								name=event.effect_id,
-								source = HitEntity,
-								position = HitEntity.position,
-								target = target,
-								speed=speed,
-								max_range = storage.ItemCannonRange or 200
-							}
-							-- Ultracube irreplaceables detection & handling
-							if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
-								-- Create a dummy FlyingItem so we can track it for Ultracube
-								InvokeThrownItem({
-									type = "ItemShell",
-									ItemName = ItemName,
-									count = prototypes.item[ItemName].stack_size,
-									quality = QualityName,
-									start = HitPosition,
-									target = target,
-									surface = surface,
-									projectile = projectile,
-								})
-							end
-
-							if (not LaserPointer) then
-								HitEntity.energy = 0
-								surface.play_sound
-								{
-									path = "RTRicochetPanelSpark",
-									position = HitEntity.position,
-									volume_modifier = 0.5
-								}
-								rendering.draw_animation
-								{
-									animation = "RTRicochetPanelZap",
-									target = {entity=HitEntity, offset={0,-0.6}},
-									surface = HitEntity.surface,
-									time_to_live = 20,
-									x_scale = 0.4,
-									y_scale = 0.4,
-								}
-							end
-						else
-							eject = true
-							debris = false
-						end
-					else
-						eject = true
-						if (not LaserPointer) then
-							HitEntity.die()
-						end
-					end
 				else
 					eject = true
+					if (not LaserPointer) then
+						HitEntity.die()
+					end
 				end
 			else
 				eject = true
 			end
-			if (eject == true and ItemName ~= "LaserPointer") then
-				local start = event.source_position
-				local HitPosition = event.target_position
-				local deltaX = HitPosition.x - start.x
-				local deltaY = HitPosition.y - start.y
-				local angle = math.atan2(deltaY, deltaX)
-				local ProjectileOrientation = (angle / (2 * math.pi)) % 1
-				local StartOffset = {0, 0}
-				if (debris == false) then
-					StartOffset = {0, -1}
-				end
-				local RemainingCount = prototypes.item[ItemName].stack_size - inserted
-				local GroupSize = math.ceil(RemainingCount/17) -- each stack will launch out as maximum 17 projectiles per wagon (plus one for remainder)
-				while RemainingCount > 0 do
-					local AngleSpread = math.random(-40,40)*0.001
-					local xUnit = math.cos(2*math.pi*(ProjectileOrientation+AngleSpread))
-					local yUnit = math.sin(2*math.pi*(ProjectileOrientation+AngleSpread))
-					local ForwardSpread = math.random(1000,3000)*0.01
-					local TargetX = HitPosition.x + (ForwardSpread*0.6*xUnit)-- + (HorizontalSpread*wagon.speed*yUnit)
-					local TargetY = HitPosition.y + (ForwardSpread*0.6*yUnit)-- + (HorizontalSpread*wagon.speed*xUnit)
-					local count = math.min(GroupSize, RemainingCount)
-					InvokeThrownItem({
-						type = "ReskinnedStream",
-						ItemName = ItemName,
-						count = count,
-						quality = QualityName,
-						speed = 0.6,
-						start = OffsetPosition(HitPosition, StartOffset),
-						target = {TargetX, TargetY},
-						surface = surface,
-						space = false,
-					})
-					RemainingCount = RemainingCount - count
-				end
+		else
+			eject = true
+		end
+		if (eject == true and ItemName ~= "LaserPointer") then
+			local start = event.source_position
+			local HitPosition = event.target_position
+			local deltaX = HitPosition.x - start.x
+			local deltaY = HitPosition.y - start.y
+			local angle = math.atan2(deltaY, deltaX)
+			local ProjectileOrientation = (angle / (2 * math.pi)) % 1
+			local StartOffset = {0, 0}
+			if (debris == false) then
+				StartOffset = {0, -1}
+			end
+			local RemainingCount = prototypes.item[ItemName].stack_size - inserted
+			local GroupSize = math.ceil(RemainingCount/17) -- each stack will launch out as maximum 17 projectiles per wagon (plus one for remainder)
+			while RemainingCount > 0 do
+				local AngleSpread = math.random(-40,40)*0.001
+				local xUnit = math.cos(2*math.pi*(ProjectileOrientation+AngleSpread))
+				local yUnit = math.sin(2*math.pi*(ProjectileOrientation+AngleSpread))
+				local ForwardSpread = math.random(1000,3000)*0.01
+				local TargetX = HitPosition.x + (ForwardSpread*0.6*xUnit)-- + (HorizontalSpread*wagon.speed*yUnit)
+				local TargetY = HitPosition.y + (ForwardSpread*0.6*yUnit)-- + (HorizontalSpread*wagon.speed*xUnit)
+				local count = math.min(GroupSize, RemainingCount)
+				InvokeThrownItem({
+					type = "ReskinnedStream",
+					ItemName = ItemName,
+					count = count,
+					quality = QualityName,
+					speed = 0.6,
+					start = OffsetPosition(HitPosition, StartOffset),
+					target = {TargetX, TargetY},
+					surface = surface,
+					space = false,
+				})
+				RemainingCount = RemainingCount - count
+			end
 
-				-- Ultracube irreplaceables detection & handling: make sure the remaining items are spilled
-				if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
+			-- Ultracube irreplaceables detection & handling: make sure the remaining items are spilled
+			if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
 
-				end
-				if (debris) then
-					surface.create_entity
-					({
-						name = "RTItemShellImpact",
-						position = HitPosition,
-						target = HitPosition,
-						speed = 5
-					})
-					surface.create_entity
-					({
-						name = "wall-explosion",
-						position = HitPosition
-					})
-				else
-					surface.play_sound
-					{
-						path = "RTHitWrongAngle",
-						position = HitPosition,
-					}
-				end
-			elseif (eject == false and ItemName ~= "LaserPointer") then
+			end
+			if (debris) then
+				surface.create_entity
+				({
+					name = "RTItemShellImpact",
+					position = HitPosition,
+					target = HitPosition,
+					speed = 5
+				})
+				surface.create_entity
+				({
+					name = "wall-explosion",
+					position = HitPosition
+				})
+			else
 				surface.play_sound
 				{
-					path = "RTRicochetPanelSound",
-					position = event.target_position
+					path = "RTHitWrongAngle",
+					position = HitPosition,
 				}
 			end
+		elseif (eject == false and ItemName ~= "LaserPointer") then
+			surface.play_sound
+			{
+				path = "RTRicochetPanelSound",
+				position = event.target_position
+			}
 		end
 
 	elseif (event.effect_id == "BeltRampPlayer") then

--- a/script/event/effect_triggered.lua
+++ b/script/event/effect_triggered.lua
@@ -93,7 +93,7 @@ local function effect_triggered(event)
 			end
 			storage.PrimerThrowerLinks[DetectorNumber].ready = false
 		end
-		
+
 	elseif (string.find(event.effect_id, "RTItemShell")) then
 		local ItemName, QualityName = string.match(event.effect_id, "^RTItemShell(.+)%-Q%-(.*)$")
 		local eject = false
@@ -107,7 +107,6 @@ local function effect_triggered(event)
 		end
 
 		-- Ultracube irreplaceables detection & handling
-		local skip_ultracube = false
 		if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
 			-- Release the token so we can fire a bounced projectile / insert it into the world
 			-- If Ultracube recovered the item don't do anything
@@ -391,11 +390,6 @@ local function effect_triggered(event)
 					space = false,
 				})
 				RemainingCount = RemainingCount - count
-			end
-
-			-- Ultracube irreplaceables detection & handling: make sure the remaining items are spilled
-			if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
-
 			end
 			if (debris) then
 				surface.create_entity

--- a/script/event/effect_triggered.lua
+++ b/script/event/effect_triggered.lua
@@ -105,250 +105,326 @@ local function effect_triggered(event)
 			speed = 0.75
 			LaserPointer = true
 		end
-		if (event.target_entity) then
-			local HitEntity = event.target_entity
-			if (HitEntity.name == "RTRicochetPanel") then
-				if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
-					-- the following code was brought to you by ChatGPT cause im way too dumb to come up with this but basically it reflects the item shell off the panel in an angle in = angle out way based on whether the panel is vertical or horizontal. It's actually good enough to handle the panel being at any angle but that sounds like a pain to actually use in game
+
+		-- Ultracube irreplaceables detection & handling
+		local skip_ultracube = false
+		if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
+			-- Release the token so we can fire a bounced projectile / insert it into the world
+			-- If Ultracube recovered the item don't do anything
+			local projectile = surface.find_entity(event.effect_id, event.target_position)
+			if not CubeFlyingItems.release_for_projectile(projectile) then
+				skip_ultracube = true
+			end
+		end
+
+		if not skip_ultracube then
+			if (event.target_entity) then
+				local HitEntity = event.target_entity
+				if (HitEntity.name == "RTRicochetPanel") then
+					if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
+						-- the following code was brought to you by ChatGPT cause im way too dumb to come up with this but basically it reflects the item shell off the panel in an angle in = angle out way based on whether the panel is vertical or horizontal. It's actually good enough to handle the panel being at any angle but that sounds like a pain to actually use in game
+							local start = event.source_position
+							local HitPosition = event.target_position
+							local object = HitEntity
+							-- positions
+							local p_x, p_y = start.x, start.y
+							local o_x, o_y = HitPosition.x, HitPosition.y
+							local PanelOrientation = object.orientation  -- [0, 1)
+							-- 1) Compute the projectile's incoming direction (v_x, v_y).
+							--    Let's assume we want center-to-center for simplicity:
+							local v_x = o_x - p_x
+							local v_y = o_y - p_y
+							local v_len = math.sqrt(v_x*v_x + v_y*v_y)
+							if v_len > 0 then
+								v_x = v_x / v_len
+								v_y = v_y / v_len
+							end
+							-- 2) Compute the normal from Factorio orientation
+							local theta = 2 * math.pi * PanelOrientation
+							local n_x = math.cos(theta - math.pi/2)
+							local n_y = math.sin(theta - math.pi/2)
+							-- 3) Reflect v about n
+							local dot = (v_x * n_x) + (v_y * n_y)
+							local r_x = v_x - 2 * dot * n_x
+							local r_y = v_y - 2 * dot * n_y
+							-- r_x, r_y now points in the bounced (reflected) direction.
+						local target = OffsetPosition(HitPosition, {100*r_x, 100*r_y})
+						local projectile = surface.create_entity
+						{
+							name=event.effect_id,
+							source = HitEntity,
+							position = HitPosition,
+							target = target,
+							speed=speed,
+							max_range = storage.ItemCannonRange or 200
+						}
+
+						-- Ultracube irreplaceables detection & handling
+						if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
+							-- Create a dummy FlyingItem so we can track it for Ultracube
+							InvokeThrownItem({
+								type = "ItemShell",
+								ItemName = ItemName,
+								count = prototypes.item[ItemName].stack_size,
+								quality = QualityName,
+								start = HitPosition,
+								target = target,
+								surface = surface,
+								projectile = projectile,
+							})
+						end
+
+						if (not LaserPointer) then
+							HitEntity.energy = 0
+							surface.play_sound
+							{
+								path = "RTRicochetPanelSpark",
+								position = HitEntity.position,
+								volume_modifier = 0.5
+							}
+							rendering.draw_animation
+							{
+								animation = "RTRicochetPanelZap",
+								target = {entity=HitEntity, offset={0,-0.6}},
+								surface = HitEntity.surface,
+								time_to_live = 20,
+								x_scale = 0.4,
+								y_scale = 0.8,
+							}
+						end
+					else
+						eject = true
+						--debris = false
+						if (not LaserPointer) then
+							HitEntity.die()
+						end
+					end
+				elseif (HitEntity.name == "RTCatchingChute" and not LaserPointer) then
+					surface.play_sound
+					{
+						path = "RTClunk",
+						position = HitEntity.position
+					}
+					inserted = HitEntity.insert({name=ItemName, count=prototypes.item[ItemName].stack_size, quality=QualityName})
+					if (inserted < prototypes.item[ItemName].stack_size) then
+						eject = true
+						debris = false
+					end
+					-- Ultracube irreplaceables detection & handling
+					if storage.Ultracube and inserted > 0 and storage.Ultracube.prototypes.cube[ItemName] then
+						-- hint if needed
+						remote.call("Ultracube", "hint_entity", HitEntity)
+					end
+				elseif (HitEntity.name == "RTMergingChute") then
+					if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
 						local start = event.source_position
 						local HitPosition = event.target_position
-						local object = HitEntity
-						-- positions
-						local p_x, p_y = start.x, start.y
-						local o_x, o_y = HitPosition.x, HitPosition.y
-						local PanelOrientation = object.orientation  -- [0, 1)
-						-- 1) Compute the projectile's incoming direction (v_x, v_y).
-						--    Let's assume we want center-to-center for simplicity:
-						local v_x = o_x - p_x
-						local v_y = o_y - p_y
-						local v_len = math.sqrt(v_x*v_x + v_y*v_y)
-						if v_len > 0 then
-							v_x = v_x / v_len
-							v_y = v_y / v_len
-						end
-						-- 2) Compute the normal from Factorio orientation
-						local theta = 2 * math.pi * PanelOrientation
-						local n_x = math.cos(theta - math.pi/2)
-						local n_y = math.sin(theta - math.pi/2)
-						-- 3) Reflect v about n
-						local dot = (v_x * n_x) + (v_y * n_y)
-						local r_x = v_x - 2 * dot * n_x
-						local r_y = v_y - 2 * dot * n_y
-						-- r_x, r_y now points in the bounced (reflected) direction.
-					surface.create_entity
-					{
-						name=event.effect_id,
-						source = HitEntity,
-						position = HitPosition,
-						target = OffsetPosition(HitPosition, {100*r_x, 100*r_y}),
-						speed=speed,
-						max_range = storage.ItemCannonRange or 200
-					}
-					if (not LaserPointer) then
-						HitEntity.energy = 0
-						surface.play_sound
-						{
-							path = "RTRicochetPanelSpark",
-							position = HitEntity.position,
-							volume_modifier = 0.5
-						}
-						rendering.draw_animation
-						{
-							animation = "RTRicochetPanelZap",
-							target = {entity=HitEntity, offset={0,-0.6}},
-							surface = HitEntity.surface,
-							time_to_live = 20,
-							x_scale = 0.4,
-							y_scale = 0.8,
-						}
-					end
-				else
-					eject = true
-					--debris = false
-					if (not LaserPointer) then
-						HitEntity.die()
-					end
-				end
-			elseif (HitEntity.name == "RTCatchingChute" and not LaserPointer) then
-				surface.play_sound
-				{
-					path = "RTClunk",
-					position = HitEntity.position
-				}
-				inserted = HitEntity.insert({name=ItemName, count=prototypes.item[ItemName].stack_size, quality=QualityName})
-				if (inserted < prototypes.item[ItemName].stack_size) then
-					eject = true
-					debris = false
-				end
-			elseif (HitEntity.name == "RTMergingChute") then
-				if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
-					local start = event.source_position
-					local HitPosition = event.target_position
-					local deltaX = HitPosition.x - start.x
-					local deltaY = HitPosition.y - start.y
-					local angle = math.atan2(deltaY, deltaX) - 3*math.pi/4 -- to align with the 45 degree tilt of the chute
-					local ProjectileOrientation = (angle / (2 * math.pi)) % 1
-					if (ProjectileOrientation ~= HitEntity.orientation and (ProjectileOrientation+0.5)%1 ~= HitEntity.orientation) then
-						local OutVector = storage.ChuteOrientationComponents[HitEntity.orientation]
-						surface.create_entity
-						{
-							name=event.effect_id,
-							source = HitEntity,
-							position = HitEntity.position,
-							target = OffsetPosition(HitEntity.position, {100*OutVector.x, 100*OutVector.y}),
-							speed=speed,
-							max_range = storage.ItemCannonRange or 200
-						}
-						if (not LaserPointer) then
-							HitEntity.energy = 0
-							surface.play_sound
+						local deltaX = HitPosition.x - start.x
+						local deltaY = HitPosition.y - start.y
+						local angle = math.atan2(deltaY, deltaX) - 3*math.pi/4 -- to align with the 45 degree tilt of the chute
+						local ProjectileOrientation = (angle / (2 * math.pi)) % 1
+						if (ProjectileOrientation ~= HitEntity.orientation and (ProjectileOrientation+0.5)%1 ~= HitEntity.orientation) then
+							local OutVector = storage.ChuteOrientationComponents[HitEntity.orientation]
+							local target = OffsetPosition(HitEntity.position, {100*OutVector.x, 100*OutVector.y})
+							local projectile = surface.create_entity
 							{
-								path = "RTRicochetPanelSpark",
+								name=event.effect_id,
+								source = HitEntity,
 								position = HitEntity.position,
-								volume_modifier = 0.5
+								target = target,
+								speed=speed,
+								max_range = storage.ItemCannonRange or 200
 							}
-							rendering.draw_animation
-							{
-								animation = "RTRicochetPanelZap",
-								target = {entity=HitEntity, offset={0,-0.6}},
-								surface = HitEntity.surface,
-								time_to_live = 20,
-								x_scale = 0.4,
-								y_scale = 0.4,
-							}
-						end
-					else
-						eject = true
-						debris = false
-					end
-				else
-					eject = true
-					if (not LaserPointer) then
-						HitEntity.die()
-					end
-				end
-			elseif (HitEntity.name == "RTDivergingChute") then
-				if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
-					local start = event.source_position
-					local HitPosition = event.target_position
-					local deltaX = HitPosition.x - start.x
-					local deltaY = HitPosition.y - start.y
-					local angle = math.atan2(deltaY, deltaX) - 3*math.pi/4 -- to align with the 45 degree tilt of the chute
-					local ProjectileOrientation = (angle / (2 * math.pi)) % 1
-					--game.print(ProjectileOrientation.." | "..HitEntity.orientation)
-					--if (math.floor((ProjectileOrientation*100) + 0.5) == math.floor((HitEntity.orientation*100) + 0.5)) then
-					if (ProjectileOrientation == HitEntity.orientation) then
-						local OutX = storage.ChuteOrientationComponents[HitEntity.orientation].x
-						local OutY = storage.ChuteOrientationComponents[HitEntity.orientation].y
-						-- flips either X or Y direction to bounce out one way or the other. destructible isn't relavent 99% of the time so i use it to track the direction it deflected last
-						if (HitEntity.destructible) then
-							OutX = -OutX
-							HitEntity.destructible = false
+
+							-- Ultracube irreplaceables detection & handling
+							if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
+								-- Create a dummy FlyingItem so we can track it for Ultracube
+								InvokeThrownItem({
+									type = "ItemShell",
+									ItemName = ItemName,
+									count = prototypes.item[ItemName].stack_size,
+									quality = QualityName,
+									start = HitEntity.position,
+									target = target,
+									surface = surface,
+									projectile = projectile,
+								})
+							end
+
+							if (not LaserPointer) then
+								HitEntity.energy = 0
+								surface.play_sound
+								{
+									path = "RTRicochetPanelSpark",
+									position = HitEntity.position,
+									volume_modifier = 0.5
+								}
+								rendering.draw_animation
+								{
+									animation = "RTRicochetPanelZap",
+									target = {entity=HitEntity, offset={0,-0.6}},
+									surface = HitEntity.surface,
+									time_to_live = 20,
+									x_scale = 0.4,
+									y_scale = 0.4,
+								}
+							end
 						else
-							OutY = -OutY
-							HitEntity.destructible = true
-						end
-						surface.create_entity
-						{
-							name=event.effect_id,
-							source = HitEntity,
-							position = HitEntity.position,
-							target = OffsetPosition(HitEntity.position, {100*OutX, 100*OutY}),
-							speed=speed,
-							max_range = storage.ItemCannonRange or 200
-						}
-						if (not LaserPointer) then
-							HitEntity.energy = 0
-							surface.play_sound
-							{
-								path = "RTRicochetPanelSpark",
-								position = HitEntity.position,
-								volume_modifier = 0.5
-							}
-							rendering.draw_animation
-							{
-								animation = "RTRicochetPanelZap",
-								target = {entity=HitEntity, offset={0,-0.6}},
-								surface = HitEntity.surface,
-								time_to_live = 20,
-								x_scale = 0.4,
-								y_scale = 0.4,
-							}
+							eject = true
+							debris = false
 						end
 					else
 						eject = true
-						debris = false
+						if (not LaserPointer) then
+							HitEntity.die()
+						end
+					end
+				elseif (HitEntity.name == "RTDivergingChute") then
+					if (HitEntity.energy/HitEntity.electric_buffer_size > 0.75) then
+						local start = event.source_position
+						local HitPosition = event.target_position
+						local deltaX = HitPosition.x - start.x
+						local deltaY = HitPosition.y - start.y
+						local angle = math.atan2(deltaY, deltaX) - 3*math.pi/4 -- to align with the 45 degree tilt of the chute
+						local ProjectileOrientation = (angle / (2 * math.pi)) % 1
+						--game.print(ProjectileOrientation.." | "..HitEntity.orientation)
+						--if (math.floor((ProjectileOrientation*100) + 0.5) == math.floor((HitEntity.orientation*100) + 0.5)) then
+						if (ProjectileOrientation == HitEntity.orientation) then
+							local OutX = storage.ChuteOrientationComponents[HitEntity.orientation].x
+							local OutY = storage.ChuteOrientationComponents[HitEntity.orientation].y
+							-- flips either X or Y direction to bounce out one way or the other. destructible isn't relavent 99% of the time so i use it to track the direction it deflected last
+							if (HitEntity.destructible) then
+								OutX = -OutX
+								HitEntity.destructible = false
+							else
+								OutY = -OutY
+								HitEntity.destructible = true
+							end
+							local target = OffsetPosition(HitEntity.position, {100*OutX, 100*OutY})
+							local projectile = surface.create_entity
+							{
+								name=event.effect_id,
+								source = HitEntity,
+								position = HitEntity.position,
+								target = target,
+								speed=speed,
+								max_range = storage.ItemCannonRange or 200
+							}
+							-- Ultracube irreplaceables detection & handling
+							if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
+								-- Create a dummy FlyingItem so we can track it for Ultracube
+								InvokeThrownItem({
+									type = "ItemShell",
+									ItemName = ItemName,
+									count = prototypes.item[ItemName].stack_size,
+									quality = QualityName,
+									start = HitPosition,
+									target = target,
+									surface = surface,
+									projectile = projectile,
+								})
+							end
+
+							if (not LaserPointer) then
+								HitEntity.energy = 0
+								surface.play_sound
+								{
+									path = "RTRicochetPanelSpark",
+									position = HitEntity.position,
+									volume_modifier = 0.5
+								}
+								rendering.draw_animation
+								{
+									animation = "RTRicochetPanelZap",
+									target = {entity=HitEntity, offset={0,-0.6}},
+									surface = HitEntity.surface,
+									time_to_live = 20,
+									x_scale = 0.4,
+									y_scale = 0.4,
+								}
+							end
+						else
+							eject = true
+							debris = false
+						end
+					else
+						eject = true
+						if (not LaserPointer) then
+							HitEntity.die()
+						end
 					end
 				else
 					eject = true
-					if (not LaserPointer) then
-						HitEntity.die()
-					end
 				end
 			else
 				eject = true
 			end
-		else
-			eject = true
-		end
-		if (eject == true and ItemName ~= "LaserPointer") then
-			local start = event.source_position
-			local HitPosition = event.target_position
-			local deltaX = HitPosition.x - start.x
-			local deltaY = HitPosition.y - start.y
-			local angle = math.atan2(deltaY, deltaX)
-			local ProjectileOrientation = (angle / (2 * math.pi)) % 1
-			local StartOffset = {0, 0}
-			if (debris == false) then
-				StartOffset = {0, -1}
-			end
-			local count = prototypes.item[ItemName].stack_size - inserted
-			local GroupSize = math.ceil(count/17) -- each stack will launch out as maximum 17 projectiles per wagon
-			for _ = 1, math.floor(count/GroupSize) do
-				local AngleSpread = math.random(-40,40)*0.001
-				local xUnit = math.cos(2*math.pi*(ProjectileOrientation+AngleSpread))
-				local yUnit = math.sin(2*math.pi*(ProjectileOrientation+AngleSpread))
-				local ForwardSpread = math.random(1000,3000)*0.01
-				local TargetX = HitPosition.x + (ForwardSpread*0.6*xUnit)-- + (HorizontalSpread*wagon.speed*yUnit)
-				local TargetY = HitPosition.y + (ForwardSpread*0.6*yUnit)-- + (HorizontalSpread*wagon.speed*xUnit)
-				InvokeThrownItem({
-					type = "ReskinnedStream",
-					ItemName = ItemName,
-					count = GroupSize,
-					quality = QualityName,
-					speed = 0.6,
-					start = OffsetPosition(HitPosition, StartOffset),
-					target = {TargetX, TargetY},
-					surface = surface,
-					space = false,
-				})
-			end
-			if (debris) then
-				surface.create_entity
-				({
-					name = "RTItemShellImpact",
-					position = HitPosition,
-					target = HitPosition,
-					speed = 5
-				})
-				surface.create_entity
-				({
-					name = "wall-explosion",
-					position = HitPosition
-				})
-			else
+			if (eject == true and ItemName ~= "LaserPointer") then
+				local start = event.source_position
+				local HitPosition = event.target_position
+				local deltaX = HitPosition.x - start.x
+				local deltaY = HitPosition.y - start.y
+				local angle = math.atan2(deltaY, deltaX)
+				local ProjectileOrientation = (angle / (2 * math.pi)) % 1
+				local StartOffset = {0, 0}
+				if (debris == false) then
+					StartOffset = {0, -1}
+				end
+				local RemainingCount = prototypes.item[ItemName].stack_size - inserted
+				local GroupSize = math.ceil(RemainingCount/17) -- each stack will launch out as maximum 17 projectiles per wagon (plus one for remainder)
+				while RemainingCount > 0 do
+					local AngleSpread = math.random(-40,40)*0.001
+					local xUnit = math.cos(2*math.pi*(ProjectileOrientation+AngleSpread))
+					local yUnit = math.sin(2*math.pi*(ProjectileOrientation+AngleSpread))
+					local ForwardSpread = math.random(1000,3000)*0.01
+					local TargetX = HitPosition.x + (ForwardSpread*0.6*xUnit)-- + (HorizontalSpread*wagon.speed*yUnit)
+					local TargetY = HitPosition.y + (ForwardSpread*0.6*yUnit)-- + (HorizontalSpread*wagon.speed*xUnit)
+					local count = math.min(GroupSize, RemainingCount)
+					InvokeThrownItem({
+						type = "ReskinnedStream",
+						ItemName = ItemName,
+						count = count,
+						quality = QualityName,
+						speed = 0.6,
+						start = OffsetPosition(HitPosition, StartOffset),
+						target = {TargetX, TargetY},
+						surface = surface,
+						space = false,
+					})
+					RemainingCount = RemainingCount - count
+				end
+
+				-- Ultracube irreplaceables detection & handling: make sure the remaining items are spilled
+				if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[ItemName] then
+
+				end
+				if (debris) then
+					surface.create_entity
+					({
+						name = "RTItemShellImpact",
+						position = HitPosition,
+						target = HitPosition,
+						speed = 5
+					})
+					surface.create_entity
+					({
+						name = "wall-explosion",
+						position = HitPosition
+					})
+				else
+					surface.play_sound
+					{
+						path = "RTHitWrongAngle",
+						position = HitPosition,
+					}
+				end
+			elseif (eject == false and ItemName ~= "LaserPointer") then
 				surface.play_sound
 				{
-					path = "RTHitWrongAngle",
-					position = HitPosition,
+					path = "RTRicochetPanelSound",
+					position = event.target_position
 				}
 			end
-		elseif (eject == false and ItemName ~= "LaserPointer") then
-			surface.play_sound
-			{
-				path = "RTRicochetPanelSound",
-				position = event.target_position
-			}
 		end
 
 	elseif (event.effect_id == "BeltRampPlayer") then

--- a/script/event/on_tick_ItemCannons.lua
+++ b/script/event/on_tick_ItemCannons.lua
@@ -24,15 +24,30 @@ local function PersonalFitness(event)
                 and slot1.count == slot1.prototype.stack_size) then
                     local cannon = ItemCannonProperties.entity
                     if (prototypes.entity["RTItemShell"..slot1.name.."-Q-"..slot1.quality.name]) then
-                        cannon.surface.create_entity
+                        local target = OffsetPosition(cannon.position, targets[cannon.orientation])
+                        local projectile = cannon.surface.create_entity
                         {
                             name="RTItemShell"..slot1.name.."-Q-"..slot1.quality.name,
                             source = cannon,
                             position = cannon.position,
-                            target = OffsetPosition(cannon.position, targets[cannon.orientation]),
+                            target = target,
                             speed=storage.ItemCannonSpeed,
                             max_range = storage.ItemCannonRange or 200
                         }
+                        -- Ultracube irreplaceables detection & handling
+                        if storage.Ultracube and storage.Ultracube.prototypes.irreplaceable[slot1.name] then
+                            -- Create a dummy FlyingItem so we can track it for Ultracube
+                            InvokeThrownItem({
+                                type = "ItemShell",
+                                ItemName = slot1.name,
+                                count = slot1.prototype.stack_size,
+                                quality = slot1.quality.name,
+                                start = cannon.position,
+                                target = target,
+                                surface = cannon.surface,
+                                projectile = projectile,
+                            })
+                        end
                         slot1.clear()
                         --slot2.count = slot2.count - 1
                         if (ItemCannonProperties.CantLoad) then

--- a/script/trains/on_tick.lua
+++ b/script/trains/on_tick.lua
@@ -901,7 +901,6 @@ local function on_tick(event)
 								end
 							-- Spill the selected items on the ground
 							else
-								-- WIP ultracube support spill on ground driectly from wagon goes here
 								if (stackk.item_number) then
 									local substack = game.create_inventory(1)
 									substack.insert(stackk) -- inserts a copy, doesnt transfer

--- a/script/trains/on_tick.lua
+++ b/script/trains/on_tick.lua
@@ -910,7 +910,14 @@ local function on_tick(event)
 									properties.entity.surface.spill_item_stack({position=properties.entity.position, stack=substack[1]})
 									substack.destroy()
 								else
-									properties.entity.surface.spill_item_stack({position=properties.entity.position, stack=stackk})
+									local entities = properties.entity.surface.spill_item_stack({position=properties.entity.position, stack=stackk})
+									if storage.Ultracube then
+										for _, entity in ipairs(entities) do
+											if storage.Ultracube.prototypes.cube[entity.name] then
+												remote.call("Ultracube", "hint_entity", entity)
+											end
+										end
+									end
 								end
 							end
 						end

--- a/script/trains/on_tick.lua
+++ b/script/trains/on_tick.lua
@@ -358,7 +358,7 @@ local function on_tick(event)
 						else
 							SpeedPolarity = -1
 						end
-						
+
 						if (properties.schedule ~= nil) then
 							reEnableSchedule(NewTrain.train, properties.schedule, properties.destinationStation, properties)
 						end
@@ -371,7 +371,7 @@ local function on_tick(event)
 						) then
 							NewTrain.train.manual_mode = properties.ManualMode -- TrainreEnableSchedules are default created in manual mode, and connecting a new carriage switches back to manual
 						end
-						
+
 						if (properties.leader == nil) then
 							if ((properties.ghostLoco ~= nil and properties.ghostLoco.valid == true and properties.RampOrientation == properties.ghostLoco.orientation)
 							or (properties.RampOrientation == properties.orientation))then
@@ -387,7 +387,7 @@ local function on_tick(event)
 							--end
 						end
 
-						
+
 						if (properties.gridd ~= nil and NewTrain.grid ~= nil) then
 							for each, equip in pairs(properties.gridd) do
 								NewTrain.grid.put
@@ -407,7 +407,7 @@ local function on_tick(event)
 								-- Ultracube handling
 								if storage.Ultracube then
 									remote.call("Ultracube", "reset_ultralocomotion_fuel", NewTrain) -- If locomotive was burning ultralocomotion fuel before launch, resets it on landing
-									
+
 									-- Ultracube irreplaceables handling for fuel/burnt slots & currently burning
 									if properties.Ultracube then -- Ultracube is active and this locomotive has irreplaceables in it
 										if properties.Ultracube.tokens[defines.inventory.fuel] then -- There were irreplaceables in the fuel inventory
@@ -421,14 +421,14 @@ local function on_tick(event)
 										end
 									end
 								end
-								
+
 								for each, stack in pairs(properties.FuelInventory) do
 									NewTrain.burner.inventory.insert({name=stack.name, count=stack.count, quality=stack.quality})
 								end
 								for each, stack in pairs(properties.BurntFuelInventory) do
 									NewTrain.burner.burnt_result_inventory.insert({name=stack.name, count=stack.count, quality=stack.quality})
 								end
-								
+
 							end
 						elseif (NewTrain.type == "cargo-wagon") then
 							local WagonInventory = NewTrain.get_inventory(defines.inventory.cargo_wagon)
@@ -678,7 +678,6 @@ local function on_tick(event)
 					if (NumItems > 0) then
 						local spill = {}
 						local wagon = GuideCar
-
 						local slot = math.random(NumItems)
 						local stack = items[slot]
 						if storage.Ultracube and properties.Ultracube and slot > #items then

--- a/script/ultracube/cube_flying_items.lua
+++ b/script/ultracube/cube_flying_items.lua
@@ -59,7 +59,7 @@ function cube_flying_items.item_with_path_update(FlyingItem, duration)
 	local p1, p2
 	if FlyingItem.path[duration-1] then
 		p1, p2 = FlyingItem.path[duration-1], position
-	else if FlyingItem.path[duration+1] then
+	elseif FlyingItem.path[duration+1] then
 		p1, p2 = position, FlyingItem.path[duration+1]
 	end
 	local velocity = p1 and p2 and {
@@ -77,7 +77,7 @@ function cube_flying_items.item_with_path_update(FlyingItem, duration)
 	)
 end
 
--- Used to update the ownership token for items using the stream projectile
+-- Used to update token for items using the stream projectile
 function cube_flying_items.item_with_stream_update(FlyingItem)
 	local delta = (game.tick-FlyingItem.StartTick)/FlyingItem.AirTime -- 0-1 float corresponding to how far along the item should be between starting and finishing position
 	-- Vector from start position to end position scaled by delta to get vector for distance traveled, and then added to start position to get a rough 'ground' position

--- a/script/ultracube/cube_flying_items.lua
+++ b/script/ultracube/cube_flying_items.lua
@@ -1,7 +1,41 @@
 local cube_flying_items = {}
 
+-- Sets some additional properties normally not computed for ReskinnedStreams but are used to track the cube
+local function add_missing_stream_properties(FlyingItem)
+	if FlyingItem.type == "ReskinnedStream" then
+		local StartX = FlyingItem.ThrowerPosition.x or FlyingItem.ThrowerPosition[1]
+		local StartY = FlyingItem.ThrowerPosition.y or FlyingItem.ThrowerPosition[2]
+		local TargetX = FlyingItem.target.x
+		local TargetY = FlyingItem.target.y
+		local speed = FlyingItem.speed or 0.18
+		local distance = math.sqrt((TargetX-StartX)*(TargetX-StartX) + (TargetY-StartY)*(TargetY-StartY))
+		FlyingItem.AirTime = math.ceil(distance / speed) + 2  -- takes some extra ticks for the stream to be destroyed
+		FlyingItem.StartTick = game.tick
+
+		if storage.Ultracube.prototypes.cube[FlyingItem.item] then
+			-- kinda expensive, but gives us a nice arc for the cube effects / cubecam
+			local vector = {x=TargetX-StartX, y=TargetY-StartY}
+			local path = {}
+			local MaxHeight = 0.0004*(distance*distance)/(speed*speed)
+			for j = 0, FlyingItem.AirTime do
+					local progress = j/FlyingItem.AirTime
+					path[j] =
+					{
+							x = StartX+(progress*vector.x),
+							y = StartY+(progress*vector.y),
+							height = 4*MaxHeight*(progress - (progress*progress))
+					}
+			end
+			FlyingItem.path = path
+		end
+	end
+end
+
+
 -- Create an ownership token and attach it to the FlyingItem
+-- If the FlyingItem already has a token, updates it instead
 function cube_flying_items.create_token_for(FlyingItem, velocity)
+	add_missing_stream_properties(FlyingItem)
 	FlyingItem.cube_token_id = remote.call("Ultracube", "create_ownership_token",
 		FlyingItem.item,
 		FlyingItem.amount,
@@ -16,15 +50,31 @@ function cube_flying_items.create_token_for(FlyingItem, velocity)
 	FlyingItem.cube_should_hint = storage.Ultracube.prototypes.cube[FlyingItem.item] -- True if in set, otherwise Nil
 end
 
--- Used to update the ownership token for a FlyingItem that has a sprite and path
-function cube_flying_items.item_with_sprite_update(FlyingItem, duration)
+-- Used to update the ownership token for a FlyingItem that has a path
+function cube_flying_items.item_with_path_update(FlyingItem, duration)
 	local position = FlyingItem.path[duration] -- Ground position at current tick along its path
 	local height = FlyingItem.path[duration].height -- How high 'above' the ground the sprite is
+	-- Compute velocity based on position in next or previous tick
+	local velocity
+	if FlyingItem.path[duration-1] then
+		local vspeed = height - FlyingItem.path[duration-1].height
+		velocity = {
+			x = position.x - FlyingItem.path[duration-1].x,
+			y = position.y - FlyingItem.path[duration-1].y - vspeed, -- minus vspeed because +y is south
+		}
+	elseif FlyingItem.path[duration+1] then
+		local vspeed = FlyingItem.path[duration+1].height - height
+		velocity = {
+			x = FlyingItem.path[duration+1].x - position.x,
+			y = FlyingItem.path[duration+1].y - position.y - vspeed, -- minus vspeed because +y is south
+		}
+	end
 	remote.call("Ultracube", "update_ownership_token",
 		FlyingItem.cube_token_id,
 		nil, -- Timeout already set on creation. If the train was somehow going fast enough to fling something into the air longer than Ultracube's timeout limit, it's probably best to just let it be forcibly recovered
 		{
-			position = {x=position.x, y=position.y + height}, -- Render position in-air
+			position = {x=position.x, y=position.y - height}, -- Render position in-air (minus height because +y is south)
+			velocity = velocity,
 			height = height -- Used for modifying Ultracube explosion animation. Not related to where the camera follows nor the explosion's position
 		}
 	)
@@ -43,23 +93,67 @@ function cube_flying_items.item_with_stream_update(FlyingItem)
 		FlyingItem.cube_token_id,
 		nil, -- Timeout already set on creation or latest bounce
 		{
-			position = position, 
+			position = position,
 		}
 	)
 end
 
--- Used to update the ownership token for a FlyingItem after it lands on a bounce pad of any kind
-function cube_flying_items.bounce_update(FlyingItem)
+-- Used to update token for ItemShell projectiles
+function cube_flying_items.item_with_shell_update(FlyingItem)
+	-- Vector for distance traveled in 1 tick
+	local velocity = {
+		x = (FlyingItem.target.x - FlyingItem.ThrowerPosition.x) / FlyingItem.AirTime,
+		y = (FlyingItem.target.y - FlyingItem.ThrowerPosition.y) / FlyingItem.AirTime,
+	}
+	-- Start position plus velocity vector scaled by ticks since FlyingItem.StartTick
+	local DeltaTick = game.tick - FlyingItem.StartTick
+	local position = {
+		x = FlyingItem.ThrowerPosition.x + DeltaTick * velocity.x,
+		y = FlyingItem.ThrowerPosition.y + DeltaTick * velocity.y,
+	}
 	remote.call("Ultracube", "update_ownership_token",
 		FlyingItem.cube_token_id,
-		FlyingItem.AirTime+1, -- Bounce will increase total air time so update the timeout to add the new air time
+		nil, -- Timeout already set on creation or latest bounce
 		{
-			surface = FlyingItem.surface,
-			position = FlyingItem.ThrowerPosition, -- Render position
-			spill_position = FlyingItem.ThrowerPosition -- Spill position on forced recovery
+			position = position,
+			velocity = velocity,
+		}
+	)
+end
+
+-- Used to update and transfer the ownership token for a FlyingItem after it lands on a bounce pad of any kind
+function cube_flying_items.bounce_update(bouncing, NewFlyingItem)
+	add_missing_stream_properties(NewFlyingItem)
+	NewFlyingItem.cube_token_id = bouncing.cube_token_id
+	NewFlyingItem.cube_should_hint = bouncing.cube_should_hint
+	bouncing.cube_token_id = nil
+	bouncing.cube_should_hint = nil
+
+	remote.call("Ultracube", "update_ownership_token",
+		NewFlyingItem.cube_token_id,
+		NewFlyingItem.AirTime+1, -- Bounce will increase total air time so update the timeout to add the new air time
+		{
+			surface = NewFlyingItem.surface,
+			position = NewFlyingItem.ThrowerPosition, -- Render position
+			spill_position = NewFlyingItem.ThrowerPosition -- Spill position on forced recovery
 			-- TODO: Velocity parameter?
 		}
 	)
+end
+
+-- Find the FlyingItem associated with a specific projectile entity and release its token without inserting the item back into the world
+-- If the token hasn't expired returns the associated item and count; in this case a new ownership token must be created in the same tick
+function cube_flying_items.release_for_projectile(projectile)
+	if projectile then
+		for _, FlyingItem in pairs(storage.FlyingItems) do
+			if FlyingItem.projectile == projectile then
+				local cube_token_id = FlyingItem.cube_token_id
+				FlyingItem.cube_token_id = nil
+				return remote.call("Ultracube", "release_ownership_token", cube_token_id)
+			end
+		end
+	end
+	log("Warning: Could not find an Ultracube ownership token for " .. serpent.line(projectile))
 end
 
 -- Release ownership token and if it hasn't expired insert the item stack into ThingLandedOn

--- a/script/ultracube/cube_flying_trains.lua
+++ b/script/ultracube/cube_flying_trains.lua
@@ -8,9 +8,7 @@ local function _create_token_init_data(FlyingTrain)
 		spill_position = FlyingTrain.GuideCar.position
 		-- Velocity will be set on second tick in air
 	}
-	if not FlyingTrain.Ultracube.prev_pos then
-		FlyingTrain.Ultracube.prev_pos = FlyingTrain.GuideCar.position
-	end
+	FlyingTrain.Ultracube.prev_pos = FlyingTrain.GuideCar.position
 	return data
 end
 
@@ -128,7 +126,7 @@ end
 
 -- Inserts all irreplaceables associated with the given FlyingTrain into the given inventory, and sends hint_entity to Ultracube if relevant
 --[[
-	There doesn't appear to be an efficient way to maintain inventory order, 
+	There doesn't appear to be an efficient way to maintain inventory order,
 	but this will respect any filtered slots so long as the inventory has had them set before calling this function.
 ]]
 function cube_flying_trains.release_and_insert(FlyingTrain, inventory, inv_type, hint_entity)


### PR DESCRIPTION
This fixes Ultracube compatibility in the latest Factorio2.0 versions of both mods (recipe changes are needed on the Ultracube side as well https://github.com/grandseiken/factorio-ultracube/pull/65), in addition to making it compatible with the newly added Renai features (item cannons, trapdoor wagons, etc.)

Kudos to @wrothmonk for originally adding Ultracube compat; I really wanted to play with the mods together and before I knew it I was fixing the interactions with item cannons and all the other new features...

Anyways I tested everything I could think of and hopefully there aren't any issues I've missed. This is my first foray into Factorio modding so please let me know if I've missed something!

Some decisions I've made:
- Item shells carrying Ultracube items get a dummy FlyingItem created for them (that does nothing when resolved). It's just used to track the entity and its position to notify Ultracube.
- I tweaked flying item bursts (from destroyed entities / full catching chutes) to create the exact number of items ejected (half of non-Ultracube items are still destroyed when RTChestPop is on)
- I compute an arc for ReskinnedStreams if its an Ultracube item, so its position can be accurately reported to Ultracube. This otherwise doesn't replace the stream but it means the cube effects, etc. still look nice when the cube is being flung around.
- ...other stuff I've forgotten